### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -44,6 +44,10 @@ include $(BUILD_DIR)/Makefile.osx_x86_64
 else
 
 TARGET_NAME := fuse
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 LOG_PERFORMANCE = 1
 HAVE_COMPAT = 0

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -393,7 +393,10 @@ static int get_joystick(unsigned device)
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = PACKAGE_NAME;
-   info->library_version = PACKAGE_VERSION;
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version = PACKAGE_VERSION GIT_VERSION;
    info->need_fullpath = false;
    info->block_extract = false;
    info->valid_extensions = "tzx|tap|z80|rzx|scl|trd";


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.