### PR TITLE
No need to recalculate git version, it was already in version.c!

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -44,10 +44,6 @@ include $(BUILD_DIR)/Makefile.osx_x86_64
 else
 
 TARGET_NAME := fuse
-GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
-ifneq ($(GIT_VERSION)," unknown")
-	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
-endif
 
 LOG_PERFORMANCE = 1
 HAVE_COMPAT = 0

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -390,13 +390,14 @@ static int get_joystick(unsigned device)
    return 0;
 }
 
+const char *fuse_githash;
+static char version[] = PACKAGE_VERSION " .......";
+
 void retro_get_system_info(struct retro_system_info *info)
 {
+   memcpy(version + sizeof(PACKAGE_VERSION), fuse_githash, 7);
    info->library_name = PACKAGE_NAME;
-#ifndef GIT_VERSION
-#define GIT_VERSION ""
-#endif
-   info->library_version = PACKAGE_VERSION GIT_VERSION;
+   info->library_version = version;
    info->need_fullpath = false;
    info->block_extract = false;
    info->valid_extensions = "tzx|tap|z80|rzx|scl|trd";


### PR DESCRIPTION
It was pointed out in chat that fuse already generated its git hash for other purposes. This just uses that hash instead of generating its own again.