### PR TITLE
Adding Joypad to Keyboard remapping option

### DIFF
--- a/src/externs.h
+++ b/src/externs.h
@@ -43,12 +43,13 @@ extern int select_pressed;
 extern int keyb_overlay;
 extern unsigned keyb_x;
 extern unsigned keyb_y;
-extern bool joypad_state[MAX_PADS][10];
+extern bool joypad_state[MAX_PADS][16];
 extern bool keyb_state[RETROK_LAST];
 extern void* snapshot_buffer;
 extern size_t snapshot_size;
 extern void* tape_data;
 extern size_t tape_size;
+extern int joymap[16];
 extern keysyms_map_t keysyms_map[];
 
 int update_variables(int);

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -27,6 +27,13 @@ static void dummy_log(enum retro_log_level level, const char *fmt, ...)
 #define UPDATE_AV_INFO  1
 #define UPDATE_GEOMETRY 2
 #define UPDATE_MACHINE  4
+#define SPECTRUMKEYS "<none>|0|1|2|3|4|5|6|7|8|9|a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z|Enter|Caps|Symbol|Space"
+
+static const int spectrum_keys_map[] = { INPUT_KEY_NONE, INPUT_KEY_0, INPUT_KEY_1, INPUT_KEY_2, INPUT_KEY_3, INPUT_KEY_4, INPUT_KEY_5, INPUT_KEY_6, INPUT_KEY_7, INPUT_KEY_8, INPUT_KEY_9,
+      INPUT_KEY_a, INPUT_KEY_b, INPUT_KEY_c, INPUT_KEY_d, INPUT_KEY_e, INPUT_KEY_f, INPUT_KEY_g, INPUT_KEY_h, INPUT_KEY_i, INPUT_KEY_j,
+      INPUT_KEY_k, INPUT_KEY_l, INPUT_KEY_m, INPUT_KEY_n, INPUT_KEY_o, INPUT_KEY_p, INPUT_KEY_q, INPUT_KEY_r, INPUT_KEY_s, INPUT_KEY_t,
+      INPUT_KEY_u, INPUT_KEY_v, INPUT_KEY_w, INPUT_KEY_x, INPUT_KEY_y, INPUT_KEY_z,
+      INPUT_KEY_Return, INPUT_KEY_Shift_L, INPUT_KEY_Control_R, INPUT_KEY_space, };
 
 typedef struct
 {
@@ -85,12 +92,13 @@ int select_pressed;
 int keyb_overlay;
 unsigned keyb_x;
 unsigned keyb_y;
-bool joypad_state[MAX_PADS][10];
+bool joypad_state[MAX_PADS][16];
 bool keyb_state[RETROK_LAST];
 void*  snapshot_buffer;
 size_t snapshot_size;
 void* tape_data;
 size_t tape_size;
+int joymap[16];
 
 static const struct { unsigned x; unsigned y; } keyb_positions[4] = {
    { 32, 40 }, { 40, 88 }, { 48, 136 }, { 32, 184 }
@@ -237,7 +245,7 @@ keysyms_map_t keysyms_map[] = {
    { RETROK_RMETA,     INPUT_KEY_Meta_R      },
    { RETROK_LSUPER,    INPUT_KEY_Super_L     },
    { RETROK_RSUPER,    INPUT_KEY_Super_R     },
-   { 0, 0 }	// End marker: DO NOT MOVE!
+   { 0, 0 }    // End marker: DO NOT MOVE!
 };
 
 static const struct retro_variable core_vars[] =
@@ -250,6 +258,21 @@ static const struct retro_variable core_vars[] =
    { "fuse_ay_stereo_separation", "AY Stereo Separation; none|acb|abc" },
    { "fuse_key_ovrlay_transp", "Transparent Keyboard Overlay; enabled|disabled" },
    { "fuse_key_hold_time", "Time to Release Key in ms; 500|1000|100|300" },
+   { "fuse_joypad_left",    "Joypad Left mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_right",   "Joypad Right mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_up",      "Joypad Up mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_down",    "Joypad Down mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_start",   "Joypad Start mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_a",       "Joypad A button mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_b",       "Joypad B button mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_x",       "Joypad X button mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_y",       "Joypad Y button mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_l",       "Joypad L button mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_r",       "Joypad R button mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_l2",      "Joypad L2 button mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_r2",      "Joypad R2 button mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_l3",      "Joypad L3 button mapping; " SPECTRUMKEYS },
+   { "fuse_joypad_r3",      "Joypad R3 button mapping; " SPECTRUMKEYS },
    { NULL, NULL },
 };
 
@@ -370,6 +393,52 @@ int update_variables(int force)
       int option = coreopt(env_cb, core_vars, "fuse_key_hold_time", &value);
       keyb_hold_time = option >= 0 ? strtoll(value, NULL, 10) * 1000LL : 500000LL;
    }
+
+   const char* value;
+   int option = coreopt(env_cb, core_vars, "fuse_joypad_up", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_UP ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_down", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_DOWN ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_left", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_LEFT ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_right", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_RIGHT ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_a", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_A ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_b", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_B ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_x", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_X ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_y", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_Y ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_l", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_L ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_r", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_R ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_l2", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_L2 ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_r2", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_R2 ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_l3", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_L3 ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_r3", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_R3 ] = spectrum_keys_map[option];
+
+   option = coreopt(env_cb, core_vars, "fuse_joypad_start", &value );
+   joymap[ RETRO_DEVICE_ID_JOYPAD_START ] = spectrum_keys_map[option];
 
    return flags;
 }


### PR DESCRIPTION
Hi.

I'm submitting a PR to add an option to remap the joypad buttons to simulate keyboard inputs.

It works as intended, but there are a few subtleties that I'd like others' help or inputs on. I don't think they're related to this particular change, but I'd love to be able to fix them as otherwise this is not really as functional as I'd like it to be. Also, in the process of troubleshooting everything that wasn't working as intended, I noticed that the overlay wasn't simulating the Symbol Shift input on Raspbian at least (it showed as Caps Shift). I'd be surprised if this had never been noticed, so I'm open to learning that it worked as intended on other OSes, but the current version does work here. An easy test is to load Cybernoid, for instance, go to redefine keys, and try to use the overlay to send a Symbol Shift event. It will register as Caps Shift. Other games exhibit similar behaviors (games that expect Symbol Shift to do something).

Thank you @leiradel for all the pointers in the issue I had opened, and apologies for the delay - most of my time with this has been on weekends, and my debugging has been mostly with logs. I don't have a proper dev environment at the moment, and it's also my first time with more core libretro work, so I appreciate any feedback and pointers.

Issues that I'd like to fix - either in this PR  or separately:
- Saving a game's Core Remap file doesn't seem to save the device. I toyed and toyed with it but ultimately I couldn't make it work. It also seems that it doesn't save if I change it to any of the previous input types, so... where should I look? I'd like to have the ability to store a configuration stating that a specific game should load with the Keyboard Mapping as its control method, but I failed to find a way to go about it. What may I be missing? The button changes in the controls menu do seem to be saved, but the input didn't seem to.
- Adding support for more keys (L2, R2, Start in particular). Every time I tried to add those and look to parallel data structures, I ended up getting a segmentation fault somewhere down the line. I'm sure it's something fairly simple, but I ended up postponing it as I don't have a proper real-time debugging environment.

Other outstanding questions about things that were there before:
- In libretro.c, the input_descriptors structure seems to have one entry per... input type? I'm certainly not an expert in the libretro API, but I'm inclined to believe that it should actually just have one entry per port that it accepts (so, in lr-fuse's case, 2 or 3, if it's per port or per device family (Joypad, Keyboard)). Not my expertise, once again, but I believe that if I remove the ones from 4 onwards everything still works as intended.
- I couldn't get a working example of the Fuller joystick in any game I had that supposedly supported it. Is it working? I wanted to test if I had broken it but couldn't get it to work, neither in my branch nor in the master one.
- I suspect that the coreopt() function in coreopt.c isn't identifying the right index all the time, but rather a weird mix of the first entry whose first character matches the first character that's selected. I spent a lot of time around this when my KEYS option list had 'none|caps|symbol|enter|.....|a|b|c|...|e|...|n|...|s|...|z'. When I chose 'c' for instance it would return the option index for 'caps'. The way around it was to get those special entries to the end. Is that behavior as intended? It may well be - once again, first time on libretro.

Well, that's mostly it. I'd love to get anyone's feedback and pointers in the right direction in regards to anything I should change, or anything that I may have misinterpreted.

Thank you!