### PR TITLE
Change default for TRDOS files to Pentagon 512K

### DIFF
--- a/fuse/utils.c
+++ b/fuse/utils.c
@@ -133,13 +133,9 @@ utils_open_file( const char *filename, int autoload,
 
   case LIBSPECTRUM_CLASS_DISK_TRDOS:
 
-    if( !( machine_current->capabilities &
-	   LIBSPECTRUM_MACHINE_CAPABILITY_TRDOS_DISK ) &&
-        !periph_is_active( PERIPH_TYPE_BETA128 ) ) {
-      error = machine_select( LIBSPECTRUM_MACHINE_PENT ); if( error ) break;
-    }
-
-    error = beta_disk_insert( BETA_DRIVE_A, filename, autoload );
+    machine_select( LIBSPECTRUM_MACHINE_PENT512 );
+    beta_disk_insert( BETA_DRIVE_A, filename, autoload );
+    machine_reset( 1 );
     break;
 
   case LIBSPECTRUM_CLASS_DISK_GENERIC:


### PR DESCRIPTION
Currently in lr-fuse you cannot change the Spectrum model without loading a file, so when loading a TR-DOS .scl or .trd it will always use Pentagon 128K mode. This means it will take you to the TR-DOS prompt and you have to manually list the disk contents to find the filename you want and then have to type RUN"filename". This can be a long and tiresome task particularly when only using a joypad !

The patch will change the default model to Pentagon 512K when loading .scl and .trd files. This enables the GLUCK menu system where you can simple press Enter/Space to list the disk contents and then press Enter/Space again to load the first file on the disk. Much easier when you only have a joypad, plus you can boot other files that are on the disk like demos etc.

You can also go back to the TR-DOS prompt by selecting 'trdos' in the menu, and reset to 48k basic mode or open the 128K menu all from the GLUCK menu system.