### PR TITLE
Fix a crash on core load

### DIFF
--- a/fuse/keyboard.c
+++ b/fuse/keyboard.c
@@ -289,7 +289,7 @@ void fuse_keyboard_init(void)
 
   key_text = g_hash_table_new( g_int_hash, g_int_equal );
 
-  for( ptr4 = key_text_table; ptr4->key != -1; ptr4++ )
+  for( ptr4 = key_text_table; ptr4->key != (keyboard_key_name)(-1); ptr4++ )
     g_hash_table_insert( key_text, &( ptr4->key ), &( ptr4->text ) );
 
 }


### PR DESCRIPTION
When adding keys to the hash table, the core checks for -1 to end the loop, but that won't always match the -1 in the enum. Both `ptr4->key` and `-1` should be the same type in order for the comparison to work.

This change allowed me to see the title screen of a game, but the game itself seemed stuck on the loading screen. I don't know enough about the core to know whether it's just slow, or whether there is something else missing. But it doesn't crash on launch anymore with this change, at least on 3DS.

This should fix #51.