### PR TITLE
Remove obsolete and useless #define from util.c

### DIFF
--- a/fuse/utils.c
+++ b/fuse/utils.c
@@ -30,7 +30,6 @@
 #include <libgen.h>
 #endif				/* #ifdef HAVE_LIBGEN_H */
 #include <string.h>
-#include <unistd.h>
 #include <sys/stat.h>
 #include <ui/ui.h>
 

--- a/src/fuse/utils.c
+++ b/src/fuse/utils.c
@@ -1,12 +1,9 @@
 // Fix a bug in utils_find_file_path where stat is used instead of compat_file_exists
 
 // Pre-include sys/stat.h tp avoid errors with the stat macro below
-#ifndef __CELLOS_LV2__
 #include <sys/stat.h>
+#include <unistd.h>
 
 #define stat(a, b) (!compat_file_exists(a))
 #include <fuse/utils.c>
 #undef stat
-#else
-#include <fuse/utils.c>
-#endif 


### PR DESCRIPTION
`#include <unistd.h>` was moved before `#define stat(a, b) (!compat_file_exists(a))` to avoid compilation problems in some old platforms.