### PR TITLE
option size border

### DIFF
--- a/src/libretro.c
+++ b/src/libretro.c
@@ -268,7 +268,7 @@ keysyms_map_t keysyms_map[] = {
 static const struct retro_variable core_vars[] =
 {
    { "fuse_machine", "Model (needs content load); Spectrum 48K|Spectrum 48K (NTSC)|Spectrum 128K|Spectrum +2|Spectrum +2A|Spectrum +3|Spectrum +3e|Spectrum SE|Timex TC2048|Timex TC2068|Timex TS2068|Spectrum 16K|Pentagon 128K|Pentagon 512K|Pentagon 1024|Scorpion 256K" },
-   { "fuse_size_border", "Size Video Border; full|medium|small|minium|none" },
+   { "fuse_size_border", "Size Video Border; full|medium|small|minimum|none" },
    { "fuse_auto_load", "Tape Auto Load; enabled|disabled" },
    { "fuse_fast_load", "Tape Fast Load; enabled|disabled" },
    { "fuse_load_sound", "Tape Load Sound; enabled|disabled" },


### PR DESCRIPTION
I change the hide border option to the border size option.

With this you can now choose multiple border sizes:

- full, full border is shown
- medium, half of the border is shown
- small, a quarter of the border is shown
- minimum, only 4 horizontal and 3 vertical pixels are shown
- none, nothing is shown from the border

Before it was either shown whole or nothing, now in addition to these two options you can choose between three more border sizes.

Although the border in this system is not the main part of the game in many games it is used to interact with the player by changing the color of the border, I do not think it is best to remove the entire border, but if the user decides to remove it, they still have the option .
In my case I use the minimum option since I use it on a 3-inch screen and I want to see it as large but seeing a bit of border