### PR TITLE
PS3/PSL1GHT build fix

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -281,41 +281,20 @@ else ifeq ($(platform), qnx)
 	AR = QCC -Vgcc_ntoarmv7le
 	PLATFORM_DEFINES := -D__BLACKBERRY_QNX__ -fexceptions -marm -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=softfp
 
-# PS3
-else ifeq ($(platform), ps3)
-	TARGET := $(TARGET_NAME)_libretro_$(platform).a
-	CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
-	CC_AS = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
-	CXX = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-g++.exe
-	AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
-	PLATFORM_DEFINES := -D__CELLOS_LV2__
-	STATIC_LINKING = 1
-	HAVE_COMPAT = 1
-	CFLAGS += -DWORDS_BIGENDIAN -DMSB_FIRST
-	
-# sncps3
-else ifeq ($(platform), sncps3)
-	TARGET := $(TARGET_NAME)_libretro_ps3.a
-	CC = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
-	CC_AS = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
-	CXX = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
-	AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
-	PLATFORM_DEFINES := -D__CELLOS_LV2__
-	STATIC_LINKING = 1
-	HAVE_COMPAT = 1
-	CFLAGS += -DWORDS_BIGENDIAN -DMSB_FIRST
-	
 # Lightweight PS3 Homebrew SDK
-else ifeq ($(platform), psl1ght)
+else ifneq (,$(filter $(platform), ps3 psl1ght))
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
-	CC = $(PS3DEV)/ppu/bin/ppu-gcc$(EXE_EXT)
-	CC_AS = $(PS3DEV)/ppu/bin/ppu-gcc$(EXE_EXT)
-	CXX = $(PS3DEV)/ppu/bin/ppu-g++$(EXE_EXT)
-	AR = $(PS3DEV)/ppu/bin/ppu-ar$(EXE_EXT)
-	PLATFORM_DEFINES := -D__CELLOS_LV2__
+	CC = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)gcc$(EXE_EXT)
+	CC_AS = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)gcc$(EXE_EXT)
+	CXX = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)g++$(EXE_EXT)
+	AR = $(PS3DEV)/ppu/bin/ppu-$(COMMONLV)ar$(EXE_EXT)
+	PLATFORM_DEFINES := -D__PS3__
 	STATIC_LINKING = 1
 	HAVE_COMPAT = 1
 	CFLAGS += -DWORDS_BIGENDIAN -DMSB_FIRST
+	ifeq ($(platform), psl1ght)
+		PLATFORM_DEFINES += -D__PSL1GHT__ 
+	endif
 	
 # PSP
 else ifeq ($(platform), psp1)

--- a/fuse/peripherals/disk/disk.c
+++ b/fuse/peripherals/disk/disk.c
@@ -2093,14 +2093,14 @@ disk_open2( disk_t *d, const char *filename, int preindex )
   libspectrum_id_t type;
   int error;
 
-#ifdef GEKKO		/* Wii doesn't have access() */
+#if defined(GEKKO) || defined(__PS3__) /* Wii/PS3 doesn't have access() */
   d->wrprot = 0;
-#else			/* #ifdef GEKKO */
+#else			/* #ifdef GEKKO/PS3 */
   if( access( filename, W_OK ) == -1 )		/* file read only */
     d->wrprot = 1;
   else
     d->wrprot = 0;
-#endif			/* #ifdef GEKKO */
+#endif			/* #ifdef GEKKO/PS3 */
 
   if( utils_read_file( filename, &buffer.file ) )
     return d->status = DISK_OPEN;

--- a/fuse/peripherals/if1.c
+++ b/fuse/peripherals/if1.c
@@ -1264,7 +1264,7 @@ if1_mdr_write( int which, const char *filename )
 void
 if1_plug( const char *filename, int what )
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(__PS3__)
   ui_error( UI_ERROR_ERROR, "Not yet implemented on Win32" );
   return; 
 #else

--- a/fuse/peripherals/multiface.c
+++ b/fuse/peripherals/multiface.c
@@ -35,7 +35,9 @@
 #include "debugger/debugger.h"
 #include "event.h"
 #include "infrastructure/startup_manager.h"
+#ifndef __PS3__
 #include "memory.h"
+#endif
 #include "module.h"
 #include "multiface.h"
 #include "options.h"

--- a/fuse/settings.c
+++ b/fuse/settings.c
@@ -58,7 +58,7 @@
 #include "utils.h"
 
 /* The name of our configuration file */
-#ifdef WIN32
+#if defined (WIN32) || defined (__PS3__)
 #define CONFIG_FILE_NAME "fuse.cfg"
 #else				/* #ifdef WIN32 */
 #define CONFIG_FILE_NAME ".fuserc"
@@ -2741,7 +2741,7 @@ read_config_file( settings_info *settings )
 
   /* See if the file exists; if doesn't, it's not a problem */
   if( stat( path, &stat_info ) ) {
-#if defined(VITA)
+#if defined(VITA) || defined (__PS3__)
     return 0;
 #else
     if( errno == ENOENT ) {

--- a/fuse/ui/widget/filesel.c
+++ b/fuse/ui/widget/filesel.c
@@ -71,6 +71,12 @@ char *amiga_asl( char *title, BOOL is_saving );
 
 #endif /* ifdef AMIGA */
 
+#ifdef __PS3__
+#include <sys/stat.h>
+#define chdir(a) 0
+#define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
+#endif
+
 struct widget_dirent **widget_filenames; /* Filenames in the current
 					    directory */
 size_t widget_numfiles;	  /* The number of files in the current

--- a/fuse/ui/widget/widget.c
+++ b/fuse/ui/widget/widget.c
@@ -28,7 +28,9 @@
 #include <ctype.h>
 #include <errno.h>
 #include <stdlib.h>
+#ifndef __PS3__
 #include <signal.h>
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>

--- a/fuse/ui/widget/widget.h
+++ b/fuse/ui/widget/widget.h
@@ -118,11 +118,56 @@ typedef struct widget_error_t {
   const char *message;
 } widget_error_t;
 
+#ifndef __PS3__
 typedef struct widget_filesel_data widget_filesel_data;
 typedef struct widget_picture_data widget_picture_data;
 typedef struct widget_text_t widget_text_t;
 typedef struct widget_select_t widget_select_t;
 typedef struct widget_roms_info widget_roms_info;
+#else
+typedef struct widget_filesel_data {
+  int exit_all_widgets;
+  const char *title;
+} widget_filesel_data;
+typedef struct widget_picture_data {
+  const char *filename;
+  libspectrum_byte *screen;
+  int border;
+} widget_picture_data;
+typedef enum widget_text_input_allow {
+  WIDGET_INPUT_ASCII,
+  WIDGET_INPUT_DIGIT,
+  WIDGET_INPUT_ALPHA,
+  WIDGET_INPUT_ALNUM
+} widget_text_input_allow;
+typedef struct widget_text_t {
+  const char *title;
+  widget_text_input_allow allow; 
+  unsigned int max_length;
+  char text[40];
+} widget_text_t;
+
+typedef struct widget_roms_info {
+
+  int initialised;
+
+  const char *title;
+  size_t start, count;
+  int is_peripheral;
+
+} widget_roms_info;
+typedef struct widget_select_t {
+
+  const char *title;	/* Dialog title */
+  const char * const *options;	/* The available options */
+  size_t count;		/* The number of options */
+  size_t current;	/* Which option starts active? */
+
+  int result;		/* What was selected? ( -1 if dialog cancelled ) */
+  int finish_all;	/* close all widget or not */
+
+} widget_select_t;
+#endif 
 
 /* File selector (load) */
 static inline int widget_do_fileselector( widget_filesel_data *data )

--- a/fuse/ui/widget/widget_internals.h
+++ b/fuse/ui/widget/widget_internals.h
@@ -105,10 +105,12 @@ typedef struct widget_dirent {
   char *name;
 } widget_dirent;
 
+#ifndef __PS3__
 typedef struct widget_filesel_data {
   int exit_all_widgets;
   const char *title;
 } widget_filesel_data;
+#endif
 
 extern struct widget_dirent **widget_filenames;
 extern size_t widget_numfiles;
@@ -138,11 +140,13 @@ void widget_machine_keyhandler( input_key key );
 
 /* Keyboard picture */
 
+#ifndef __PS3__
 typedef struct widget_picture_data {
   const char *filename;
   libspectrum_byte *screen;
   int border;
 } widget_picture_data;
+#endif
 
 int widget_picture_draw( void* data );
 void widget_picture_keyhandler( input_key key );
@@ -162,6 +166,7 @@ scaler_type widget_select_scaler( int (*selector)( scaler_type ) );
 
 /* The generalised selector widget */
 
+#ifndef __PS3__
 typedef struct widget_select_t {
 
   const char *title;	/* Dialog title */
@@ -173,6 +178,7 @@ typedef struct widget_select_t {
   int finish_all;	/* close all widget or not */
 
 } widget_select_t;
+#endif
 
 int widget_select_draw( void *data );
 void widget_select_keyhandler( input_key key );
@@ -186,6 +192,7 @@ int widget_browse_finish( widget_finish_state finished );
 
 /* The text entry widget */
 
+#ifndef __PS3__
 typedef enum widget_text_input_allow {
   WIDGET_INPUT_ASCII,
   WIDGET_INPUT_DIGIT,
@@ -199,6 +206,7 @@ typedef struct widget_text_t {
   unsigned int max_length;
   char text[40];
 } widget_text_t;
+#endif
 
 int widget_text_draw( void* data );
 void widget_text_keyhandler( input_key key );
@@ -242,6 +250,7 @@ void widget_about_keyhandler( input_key key );
 
 /* The ROM selector widget */
 
+#ifndef __PS3__
 typedef struct widget_roms_info {
 
   int initialised;
@@ -251,6 +260,7 @@ typedef struct widget_roms_info {
   int is_peripheral;
 
 } widget_roms_info;
+#endif
 
 int widget_roms_draw( void *data );
 void widget_roms_keyhandler( input_key key );

--- a/fuse/utils.c
+++ b/fuse/utils.c
@@ -403,7 +403,13 @@ utils_read_auxiliary_file( const char *filename, utils_file *file,
   int error;
   compat_fd fd;
 
+#ifdef __PS3__
+  char fullpath[256];
+  sprintf(fullpath, "%s/%s", compat_get_config_path(),filename);
+  fd = utils_find_auxiliary_file( fullpath, type );
+#else
   fd = utils_find_auxiliary_file( filename, type );
+#endif
   if( fd == COMPAT_FILE_OPEN_FAILED ) return -1;
 
   error = utils_read_fd( fd, filename, file );

--- a/src/compat/paths.c
+++ b/src/compat/paths.c
@@ -12,8 +12,8 @@ const char *compat_get_temp_path(void)
 
 const char *compat_get_config_path(void)
 {
-#ifdef __CELLOS_LV2__
-   return "/dev_hdd0/game/SSNE10000/USRDIR/cores/system";
+#ifdef __PS3__
+   return "/dev_hdd0/game/RETROARCH/USRDIR/system";
 #else
    return "";
 #endif

--- a/src/libspectrum.h
+++ b/src/libspectrum.h
@@ -69,6 +69,14 @@ extern "C" {
 
 #endif				/* #ifdef _WIN32 */
 
+#ifdef __PS3__
+#include <fcntl.h>
+#define F_OK 0
+#define W_OK 2
+#define R_OK 4
+int access(const char *fpath, int /*mode*/);
+#endif
+
 #ifdef __GNUC__
 #define DEPRECATED __attribute__((deprecated))
 #else                           /* #ifdef __GNUC__ */

--- a/src/missing.c
+++ b/src/missing.c
@@ -1,4 +1,4 @@
-#if defined( __CELLOS_LV2__ )
+#if defined( __PS3__ )
 
 #include <stddef.h>
 
@@ -24,4 +24,5 @@ int isatty(int fd)
   (void)fd;
   return 1;
 }
+
 #endif

--- a/zlib/gzguts.h
+++ b/zlib/gzguts.h
@@ -18,7 +18,7 @@
 #  define ZLIB_INTERNAL
 #endif
 
-#if defined(_IOS_ARM64) || defined(EMSCRIPTEN) || defined(__CELLOS_LV2__)
+#if defined(_IOS_ARM64) || defined(EMSCRIPTEN) || defined(__PS3__) || defined(__PSL1GHT__)
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Inside `widget.h` and `widget_internals.h` there are many typedef redefinitions, that causes many compile errors on old gcc. So i moved (only for PS3) that typedefs from `widget_internals.h` to `widget.h`