### PR TITLE
Fix netplay mode

### DIFF
--- a/src/libretro.c
+++ b/src/libretro.c
@@ -1139,6 +1139,8 @@ bool retro_serialize(void *data, size_t size)
 
    if (size <= snapshot_size)
    {
+      // update snapshot_buffer (fuse_emulation_pause cause sound clipping at netplay)
+      snapshot_write("dummy.szx"); // filename is only used to get the snapshot type
       memcpy(data, snapshot_buffer, snapshot_size);
       res = true;
    }


### PR DESCRIPTION
It seems current Fuse doesn't work in Netplay mode bcs it updates the snapshot buffer in `retro_serialize_size()` and `retro_serialize()` just returrns its copy. Looks like authors found no way to estimate a snapshot size without making a real snapshot. In regular snapshot saving (F2 hotkey) retroarch calls `retro_serialize_size()` before `retro_serialize()` and authors decided to not making a snapshot in `retro_serialize()` again. That works, but not in a netplay mode. In Netplay mode retroarch calls `retro_serialize_size()`  once at very beginning and then calls `retro_serialize()`every time it needs to sync host and players. As the snapshot isn't really updated this results in resetting the game with a snapshot of a spectrum boot menu for all players except the host.

This patch should fix this problem.