### PR TITLE
Fix variable name collision

### DIFF
--- a/src/compat/ui.c
+++ b/src/compat/ui.c
@@ -170,9 +170,9 @@ int ui_event(void)
 
                if (is_down)
                {
-                  if (!joypad_state[port][id])
+                  if (!joyp_state[port][id])
                   {
-                     joypad_state[port][id] = true;
+                     joyp_state[port][id] = true;
 
                      if (keyboard_event)
                      {
@@ -194,9 +194,9 @@ int ui_event(void)
                }
                else
                {
-                  if (joypad_state[port][id])
+                  if (joyp_state[port][id])
                   {
-                     joypad_state[port][id] = false;
+                     joyp_state[port][id] = false;
                  
                      if (keyboard_event)
                      {
@@ -277,9 +277,9 @@ int ui_event(void)
                
                if (is_down)
                {
-                  if (!joypad_state[0][id])
+                  if (!joyp_state[0][id])
                   {
-                     joypad_state[0][id] = true;
+                     joyp_state[0][id] = true;
                      
                      switch (map[id])
                      {
@@ -321,9 +321,9 @@ int ui_event(void)
                }
                else
                {
-                  if (joypad_state[0][id])
+                  if (joyp_state[0][id])
                   {
-                     joypad_state[0][id] = false;
+                     joyp_state[0][id] = false;
                   }
                }
             }

--- a/src/externs.h
+++ b/src/externs.h
@@ -46,7 +46,7 @@ extern int select_pressed;
 extern int keyb_overlay;
 extern unsigned keyb_x;
 extern unsigned keyb_y;
-extern bool joypad_state[MAX_PADS][16];
+extern bool joyp_state[MAX_PADS][16];
 extern bool keyb_state[RETROK_LAST];
 extern void* snapshot_buffer;
 extern size_t snapshot_size;

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -112,7 +112,7 @@ int select_pressed;
 int keyb_overlay;
 unsigned keyb_x;
 unsigned keyb_y;
-bool joypad_state[MAX_PADS][16];
+bool joyp_state[MAX_PADS][16];
 bool keyb_state[RETROK_LAST];
 void*  snapshot_buffer;
 size_t snapshot_size;
@@ -709,7 +709,7 @@ bool retro_load_game(const struct retro_game_info *info)
    }
 
    env_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, input_descriptors);
-   memset(joypad_state, 0, sizeof(joypad_state));
+   memset(joyp_state, 0, sizeof(joyp_state));
    memset(keyb_state, 0, sizeof(keyb_state));
    hard_width = hard_height = soft_width = soft_height = 0;
    select_pressed = keyb_overlay = 0;


### PR DESCRIPTION
The `extern bool joypad_state` in FUSE's `src/externs.h` collides with RetroArch's own use of `joypad_state`. On certain platforms, this causes this core to either fail to build entirely or crash when anything joypad-related occurs (usually, immediately upon game start).

I've just renamed the FUSE variable from `joypad_state` to `joyp_state`, in line with the existing `keyb_state` which tracks the keyboard.

Fixes #138
Fixes #124

Might also fix the following: #133

Issue #121 was likely fixed by PR #139, but since the core stopped working on Wii U, this was not obvious until now. Regardless, that issue can also be closed.