### PR TITLE
 Fix Netplay

### DIFF
--- a/fuse/snapshot.h
+++ b/fuse/snapshot.h
@@ -34,6 +34,9 @@ int snapshot_read_buffer( const unsigned char *buffer, size_t length,
 
 int snapshot_copy_from( libspectrum_snap *snap );
 
+#ifdef __LIBRETO__
+int snapshot_update( void );
+#endif
 int snapshot_write( const char *filename );
 int snapshot_copy_to( libspectrum_snap *snap );
 

--- a/src/config_fuse.h
+++ b/src/config_fuse.h
@@ -131,7 +131,7 @@
 #define PACKAGE_BUGREPORT "http://sourceforge.net/p/fuse-emulator/bugs/"
 
 /* Define to the full name of this package. */
-#define PACKAGE_NAME "fuse"
+#define PACKAGE_NAME "Fuse"
 
 /* Define to the full name and version of this package. */
 #define PACKAGE_STRING "fuse 1.6.0"

--- a/src/externs.h
+++ b/src/externs.h
@@ -68,6 +68,7 @@ void z80_do_opcodes(void);
 int event_do_events(void);
 int fuse_emulation_pause(void);
 int fuse_emulation_unpause(void);
+int snapshot_update(void);
 int snapshot_write(const char* filename);
 int snapshot_read_buffer(const unsigned char* buffer, size_t length, libspectrum_id_t type);
 

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -1209,22 +1209,22 @@ void retro_reset(void)
 size_t retro_serialize_size(void)
 {
    fuse_emulation_pause();
-   snapshot_write("dummy.szx"); // filename is only used to get the snapshot type
+   snapshot_update();
    fuse_emulation_unpause();
    return snapshot_size;
 }
 
 bool retro_serialize(void *data, size_t size)
 {
-   bool res = false;
+   snapshot_update();
 
    if (size <= snapshot_size)
    {
       memcpy(data, snapshot_buffer, snapshot_size);
-      res = true;
+      return true;
    }
 
-   return res;
+   return false;
 }
 
 bool retro_unserialize(const void *data, size_t size)


### PR DESCRIPTION
Enable and fix Netplay by:

- Fixing the core PACKAGE_NAME
- Optimizing serialization

Co-developed and tested with @rtorralba based on:

- https://github.com/libretro/fuse-libretro/pull/129
- https://github.com/libretro/fuse-libretro/pull/130

It seems that the core/savestates are not deterministic, so the best results during testing were achieved by configuring 'Netplay Check Frames' between 50 and 100 frames.


