### PR TITLE
Add .sna and .szx snapshot support + fixed-size savestates

### DIFF
--- a/libspectrum/szx.c
+++ b/libspectrum/szx.c
@@ -2545,6 +2545,15 @@ read_chunk( libspectrum_snap *snap, libspectrum_word version,
   error = read_chunk_header( id, &data_length, buffer, end );
   if( error ) return error;
 
+#ifdef __LIBRETRO__
+  /* Hack to keep all snapshots with the same size*/
+  if (memcmp(id, "\xFF\xFF\xFF\xFF", 4) == 0)
+  {
+    *buffer = end;
+    return LIBSPECTRUM_ERROR_NONE;
+  }
+#endif
+
   if( end - *buffer < data_length ) {
     libspectrum_print_error(
       LIBSPECTRUM_ERROR_CORRUPT,


### PR DESCRIPTION
- Add .sna and .szx snapshot support.
- Restore snapshot identification using the filename extension.
- Add option to use fixed-size savestate (disabled by default).
- Patch szx to use fixed-size snapshots

## Fixed-size savestates

When netplaying, one of the peers could occasionally receive this error:

`[ERROR] [Netplay] Netplay state load with an unexpected save state size.`

This occurred because the savestate size could vary due to the internal zlib compression used by the szx snapshot format.

### Solution:

- Added an option to use fixed-size savestates
- SZX snapshots are now padded with 0xFF to maintain consistent size
- Modified SZX snapshot parser to detect padding in block headers and stop parsing when found

### Compatibility:

- Savestates remain compatible whether the fixed-size option is enabled or disabled
- Backwards compatibility maintained with savestates created by previous core version

