### PR TITLE
Add Kempston Mouse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The core options available on the frontend are:
 * AY Stereo Separation (none|acb|abc): The AY sound chip stereo separation (whatever it is)
 * Transparent Keyboard Overlay (enabled|disabled): If the keyboard overlay is transparent or opaque
 * Time to Release Key in ms (100|300|500|1000): How much time to keep a key pressed before releasing it (used when a key is pressed using the keyboard overlay)
+* Kempston Mouse Swap Buttons (disabled|enabled): Swaps the left and right Kempston Mouse button mapping
 
 ## Input Devices
 
@@ -64,6 +65,10 @@ There are some conflicts in the way the input devices interact because of the us
 
 * For joystick games: Set user 1 to a joystick type. Optionally, set user 2 to another joystick type (local cooperative games). Set user 3 to none. This way, you can use L1 as RETURN, R1 as SPACE, and SELECT to bring the embedded keyboard.
 * For keyboard games: Set users 1 and 2 to none, and user 3 to Sinclair Keyboard. You won't have any joystick and the embedded keyboard won't work, but the entire physical keyboard will be available for you to type in those text adventure commands.
+
+### Kempston Mouse
+
+Any of the three users can be set to the "Mouse" device type to emulate a Kempston Mouse. The mouse's left and right buttons map to the host mouse's left and right buttons (see the "Kempston Mouse Swap Buttons" core option to swap them); relative motion drives the Kempston Mouse position directly. Since Kempston Mouse is a single peripheral (not per-player), only set one user to Mouse at a time.
 
 If you set a joystick along with the keyboard, the joystick will work just fine except for the bindings to RETURN and SPACE, and the keyboard won't register the keys assigned to the Cursor joystick, or to the L1 and R1 buttons for all other joystick types.
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ There are some conflicts in the way the input devices interact because of the us
 * For joystick games: Set user 1 to a joystick type. Optionally, set user 2 to another joystick type (local cooperative games). Set user 3 to none. This way, you can use L1 as RETURN, R1 as SPACE, and SELECT to bring the embedded keyboard.
 * For keyboard games: Set users 1 and 2 to none, and user 3 to Sinclair Keyboard. You won't have any joystick and the embedded keyboard won't work, but the entire physical keyboard will be available for you to type in those text adventure commands.
 
-### Kempston Mouse
-
-Any of the three users can be set to the "Mouse" device type to emulate a Kempston Mouse. The mouse's left and right buttons map to the host mouse's left and right buttons (see the "Kempston Mouse Swap Buttons" core option to swap them); relative motion drives the Kempston Mouse position directly. Since Kempston Mouse is a single peripheral (not per-player), only set one user to Mouse at a time.
-
 If you set a joystick along with the keyboard, the joystick will work just fine except for the bindings to RETURN and SPACE, and the keyboard won't register the keys assigned to the Cursor joystick, or to the L1 and R1 buttons for all other joystick types.
+
+Any of the three users can also be set to the "Kempston Mouse" device type instead. The mouse's left and right buttons map to the host mouse's left and right buttons (see the "Kempston Mouse Swap Buttons" core option to swap them); relative motion drives the Kempston Mouse position directly. Since Kempston Mouse is a single peripheral (not per-player), only set one user to it at a time.
+
+If the pointer doesn't seem to do anything even though it's set to Kempston Mouse, check RetroArch's own **Settings > Input > Port *N* Controls > Mouse Index** for that user. Users 2+ default to expecting a second, third, etc. physical mouse (mouse index 1, 2, ...); on a machine with only one physical mouse, point that setting back to index 0.
 
 ## Supported Formats
 

--- a/libspectrum/szx.c
+++ b/libspectrum/szx.c
@@ -2867,9 +2867,22 @@ libspectrum_szx_write( libspectrum_buffer *buffer, int *out_flags,
     }
   }
 
+#ifdef __LIBRETRO__
+  /* Written unconditionally (like write_joy_chunk() below), not gated on
+     kempston_mouse_active: this core's Kempston Mouse peripheral can be
+     connected/disconnected mid-session via retro_set_controller_port_device(),
+     and frontends size their rewind ring buffer once from the first
+     retro_serialize_size() call, never resizing it - a snapshot that only
+     sometimes carries this chunk makes the reported size grow the first
+     time the mouse is connected, which silently breaks the rewind buffer
+     from that point on. write_amxm_chunk() already encodes "no mouse" as
+     ZXSTM_NONE, so writing it unconditionally is lossless. */
+  write_amxm_chunk( buffer, block_data, snap );
+#else
   if( libspectrum_snap_kempston_mouse_active( snap ) ) {
     write_amxm_chunk( buffer, block_data, snap );
   }
+#endif
 
   if( libspectrum_snap_simpleide_active( snap ) ) {
     write_side_chunk( buffer, block_data, snap );

--- a/src/compat/ui.c
+++ b/src/compat/ui.c
@@ -135,7 +135,25 @@ int ui_event(void)
    {
       select_pressed = false;
    }
-   
+
+   // Kempston Mouse: a single peripheral, read from whichever port (if any)
+   // is configured as RETRO_DEVICE_MOUSE. Runs regardless of keyb_overlay
+   // state since it doesn't share the joypad with the overlay navigation.
+   for (port = 0; port < MAX_PADS; port++)
+   {
+      if (input_devices[port] == RETRO_DEVICE_MOUSE)
+      {
+         int16_t dx = input_state_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
+         int16_t dy = input_state_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);
+
+         if (dx || dy)
+            ui_mouse_motion(dx, dy);
+
+         ui_mouse_button(1, input_state_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT));
+         ui_mouse_button(3, input_state_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT));
+      }
+   }
+
    if (!keyb_overlay)
    {
       unsigned id;

--- a/src/compat/ui.c
+++ b/src/compat/ui.c
@@ -137,11 +137,14 @@ int ui_event(void)
    }
 
    // Kempston Mouse: a single peripheral, read from whichever port (if any)
-   // is configured as RETRO_DEVICE_MOUSE. Runs regardless of keyb_overlay
-   // state since it doesn't share the joypad with the overlay navigation.
+   // is configured as RETRO_DEVICE_KEMPSTON_MOUSE. Runs regardless of
+   // keyb_overlay state since it doesn't share the joypad with the overlay
+   // navigation. input_state_cb() itself is still queried with the base
+   // RETRO_DEVICE_MOUSE, not the subclass - same as joystick polling below
+   // uses plain RETRO_DEVICE_JOYPAD, never one of the *_JOYSTICK subclasses.
    for (port = 0; port < MAX_PADS; port++)
    {
-      if (input_devices[port] == RETRO_DEVICE_MOUSE)
+      if (input_devices[port] == RETRO_DEVICE_KEMPSTON_MOUSE)
       {
          int16_t dx = input_state_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_X);
          int16_t dy = input_state_cb(port, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_Y);

--- a/src/externs.h
+++ b/src/externs.h
@@ -22,6 +22,11 @@
 #define RETRO_DEVICE_TIMEX2_JOYSTICK    RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 5)
 #define RETRO_DEVICE_FULLER_JOYSTICK    RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 6)
 
+// The Spectrum had more than one mouse standard (Kempston, AY, AMX); this
+// core only emulates Kempston, so name it explicitly rather than claiming
+// the generic RETRO_DEVICE_MOUSE
+#define RETRO_DEVICE_KEMPSTON_MOUSE     RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_MOUSE, 0)
+
 // These defines shouldn't be here...
 #define MAX_WIDTH  640
 #define MAX_HEIGHT 480

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -21,7 +21,6 @@
 #include <peripherals/disk/disciple.h>
 #include <pokefinder/pokemem.h>
 #include <periph.h>
-#include <machine.h>
 
 #include "ui/uimedia.h"
 
@@ -212,6 +211,7 @@ static int auto_size_savestate = 1;
 static unsigned msg_interface_version = 0;
 static int display_joystick_type;
 static int display_emulation_speed;
+static int kempston_mouse_needs_periph_update = 0;
 
 static retro_video_refresh_t video_cb;
 static retro_input_poll_t input_poll_cb;
@@ -1235,6 +1235,12 @@ void retro_run(void)
 {
    bool updated = false;
 
+   if (kempston_mouse_needs_periph_update)
+   {
+      kempston_mouse_needs_periph_update = 0;
+      periph_update();
+   }
+
    if (display_joystick_type == TRUE)
    {
       int port;
@@ -1401,11 +1407,18 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
          // "an option changed while already running"). Before fuse_init()
          // has run there is no machine/peripheral table yet to update -
          // retro_init()'s default controller setup would crash here.
-         // Kempston Mouse is also registered with hard_reset=1 (like
-         // desktop Fuse's own settings dialog), so toggling it for real
-         // needs a machine reset to actually remap the I/O ports.
-         if (fuse_init_called && periph_update())
-            machine_reset(1);
+         //
+         // Do NOT call periph_update()/machine_reset() synchronously here:
+         // frontends (RetroArch included) apply saved port/remap config
+         // right after retro_load_game() returns, before the first
+         // retro_run(). Resetting the machine at that point - before Fuse's
+         // event queue has processed a single frame - leaves the next
+         // frame interrupt event unscheduled, so retro_run()'s "wait until
+         // some_audio" loop spins forever and the frontend hangs. Defer to
+         // the top of retro_run() instead, exactly like UPDATE_MACHINE
+         // (model changes) already does.
+         if (fuse_init_called)
+            kempston_mouse_needs_periph_update = 1;
       }
    }
 }

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -418,6 +418,7 @@ static const struct retro_variable core_vars[] =
    { "fuse_key_hold_time", "Time to Release Key in ms; 500|1000|100|300" },
    { "fuse_display_joystick_type", "Display joystick type and emulation speed at startup; enabled|disabled" },
    { "fuse_auto_size_savestate", "Use Auto Size for Savestates. For Netplay 'Off' is recommended; enabled|disabled" },
+   { "fuse_mouse_swap_buttons", "Kempston Mouse Swap Buttons; disabled|enabled" },
    { "fuse_joypad_left",    "Joypad Left mapping; " SPECTRUMKEYS },
    { "fuse_joypad_right",   "Joypad Right mapping; " SPECTRUMKEYS },
    { "fuse_joypad_up",      "Joypad Up mapping; " SPECTRUMKEYS },
@@ -661,6 +662,8 @@ int update_variables(int force)
    else
       auto_size_savestate = FALSE;
 
+   settings_current.mouse_swap_buttons = coreopt(env_cb, core_vars, "fuse_mouse_swap_buttons", NULL) == 1;
+
    const char* value;
    int option = coreopt(env_cb, core_vars, "fuse_joypad_up", &value );
    joymap[ RETRO_DEVICE_ID_JOYPAD_UP ] = spectrum_keys_map[option];
@@ -758,7 +761,8 @@ void retro_set_environment(retro_environment_t cb)
       { "Timex 1 Joystick",    RETRO_DEVICE_TIMEX1_JOYSTICK    },
       { "Timex 2 Joystick",    RETRO_DEVICE_TIMEX2_JOYSTICK    },
       { "Fuller Joystick",     RETRO_DEVICE_FULLER_JOYSTICK    },
-      { "Sinclair Keyboard",   RETRO_DEVICE_SPECTRUM_KEYBOARD  }
+      { "Sinclair Keyboard",   RETRO_DEVICE_SPECTRUM_KEYBOARD  },
+      { "Kempston Mouse",      RETRO_DEVICE_MOUSE              }
    };
 
    static const struct retro_controller_info ports[MAX_PADS + 1] = {
@@ -796,11 +800,18 @@ void retro_init(void)
    total_time_ms = 0.0;
    active_cheats = NULL;
 
+   // Always report a mouse as available so Fuse auto-grabs it at startup
+   // (see fuse_init() -> ui_mouse_grab()); our ui_mouse_grab() stub in
+   // src/compat/mouse.c always succeeds, so this keeps ui_mouse_grabbed set
+   // and ui_mouse_button()/ui_mouse_motion() active whenever a port is
+   // configured as RETRO_DEVICE_MOUSE.
+   ui_mouse_present = 1;
+
    // Set default controllers
    retro_set_controller_port_device( 0, RETRO_DEVICE_CURSOR_JOYSTICK   );
    retro_set_controller_port_device( 1, RETRO_DEVICE_KEMPSTON_JOYSTICK );
    retro_set_controller_port_device( 2, RETRO_DEVICE_SPECTRUM_KEYBOARD );
-   
+
    display_joystick_type = FALSE;
    display_emulation_speed = TRUE;
 }
@@ -1360,6 +1371,22 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
             input_devices[port] = device;
          }
          break;
+   }
+
+   // Kempston Mouse is a single peripheral, not per-port; enable it in Fuse
+   // whenever any port is configured as a mouse, disable it otherwise
+   {
+      unsigned p;
+      settings_current.kempston_mouse = 0;
+
+      for (p = 0; p < MAX_PADS; p++)
+      {
+         if (input_devices[p] == RETRO_DEVICE_MOUSE)
+         {
+            settings_current.kempston_mouse = 1;
+            break;
+         }
+      }
    }
 }
 

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -20,6 +20,8 @@
 #include <peripherals/disk/opus.h>
 #include <peripherals/disk/disciple.h>
 #include <pokefinder/pokemem.h>
+#include <periph.h>
+#include <machine.h>
 
 #include "ui/uimedia.h"
 
@@ -1377,15 +1379,33 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
    // whenever any port is configured as a mouse, disable it otherwise
    {
       unsigned p;
-      settings_current.kempston_mouse = 0;
+      int kempston_mouse = 0;
 
       for (p = 0; p < MAX_PADS; p++)
       {
          if (input_devices[p] == RETRO_DEVICE_MOUSE)
          {
-            settings_current.kempston_mouse = 1;
+            kempston_mouse = 1;
             break;
          }
+      }
+
+      if (settings_current.kempston_mouse != kempston_mouse)
+      {
+         settings_current.kempston_mouse = kempston_mouse;
+
+         // Flipping settings_current.kempston_mouse alone does nothing:
+         // Fuse only (de)registers a peripheral's I/O ports when
+         // periph_update() runs (normally done by each machine's own
+         // init(), on snapshot load, etc; there is no automatic hook for
+         // "an option changed while already running"). Before fuse_init()
+         // has run there is no machine/peripheral table yet to update -
+         // retro_init()'s default controller setup would crash here.
+         // Kempston Mouse is also registered with hard_reset=1 (like
+         // desktop Fuse's own settings dialog), so toggling it for real
+         // needs a machine reset to actually remap the I/O ports.
+         if (fuse_init_called && periph_update())
+            machine_reset(1);
       }
    }
 }

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -1341,6 +1341,41 @@ void retro_deinit(void)
    }
 }
 
+// Kempston Mouse is a single peripheral, not per-port; enable it in Fuse
+// whenever any port is currently configured as a mouse, disable it
+// otherwise. This reflects live frontend port wiring, not emulated
+// machine state, so it must be re-applied after a snapshot/rewind restore
+// too - the snapshot's own kempston_mouse_active flag only reflects
+// whatever was true at the moment that particular state was captured
+// (e.g. still off, if rewound back to before the mouse was ever
+// connected), which can otherwise leave the peripheral disabled even
+// though the frontend still has a mouse wired to a port right now.
+static void sync_kempston_mouse_from_ports(void)
+{
+   unsigned p;
+   int kempston_mouse = 0;
+
+   for (p = 0; p < MAX_PADS; p++)
+   {
+      if (input_devices[p] == RETRO_DEVICE_KEMPSTON_MOUSE)
+      {
+         kempston_mouse = 1;
+         break;
+      }
+   }
+
+   if (settings_current.kempston_mouse != kempston_mouse)
+   {
+      settings_current.kempston_mouse = kempston_mouse;
+
+      // See the comment in retro_set_controller_port_device(): defer the
+      // actual periph_update() to the top of retro_run() rather than
+      // calling it here synchronously.
+      if (fuse_init_called)
+         kempston_mouse_needs_periph_update = 1;
+   }
+}
+
 void retro_set_controller_port_device(unsigned port, unsigned device)
 {
    log_cb(RETRO_LOG_INFO, "port %u device %08x\n", port, device);
@@ -1381,46 +1416,23 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
          break;
    }
 
-   // Kempston Mouse is a single peripheral, not per-port; enable it in Fuse
-   // whenever any port is configured as a mouse, disable it otherwise
-   {
-      unsigned p;
-      int kempston_mouse = 0;
-
-      for (p = 0; p < MAX_PADS; p++)
-      {
-         if (input_devices[p] == RETRO_DEVICE_KEMPSTON_MOUSE)
-         {
-            kempston_mouse = 1;
-            break;
-         }
-      }
-
-      if (settings_current.kempston_mouse != kempston_mouse)
-      {
-         settings_current.kempston_mouse = kempston_mouse;
-
-         // Flipping settings_current.kempston_mouse alone does nothing:
-         // Fuse only (de)registers a peripheral's I/O ports when
-         // periph_update() runs (normally done by each machine's own
-         // init(), on snapshot load, etc; there is no automatic hook for
-         // "an option changed while already running"). Before fuse_init()
-         // has run there is no machine/peripheral table yet to update -
-         // retro_init()'s default controller setup would crash here.
-         //
-         // Do NOT call periph_update()/machine_reset() synchronously here:
-         // frontends (RetroArch included) apply saved port/remap config
-         // right after retro_load_game() returns, before the first
-         // retro_run(). Resetting the machine at that point - before Fuse's
-         // event queue has processed a single frame - leaves the next
-         // frame interrupt event unscheduled, so retro_run()'s "wait until
-         // some_audio" loop spins forever and the frontend hangs. Defer to
-         // the top of retro_run() instead, exactly like UPDATE_MACHINE
-         // (model changes) already does.
-         if (fuse_init_called)
-            kempston_mouse_needs_periph_update = 1;
-      }
-   }
+   // Flipping settings_current.kempston_mouse alone does nothing: Fuse
+   // only (de)registers a peripheral's I/O ports when periph_update() runs
+   // (normally done by each machine's own init(), on snapshot load, etc;
+   // there is no automatic hook for "an option changed while already
+   // running"). Before fuse_init() has run there is no machine/peripheral
+   // table yet to update - retro_init()'s default controller setup would
+   // crash here.
+   //
+   // Do NOT call periph_update()/machine_reset() synchronously here:
+   // frontends (RetroArch included) apply saved port/remap config right
+   // after retro_load_game() returns, before the first retro_run().
+   // Resetting the machine at that point - before Fuse's event queue has
+   // processed a single frame - leaves the next frame interrupt event
+   // unscheduled, so retro_run()'s "wait until some_audio" loop spins
+   // forever and the frontend hangs. Defer to the top of retro_run()
+   // instead, exactly like UPDATE_MACHINE (model changes) already does.
+   sync_kempston_mouse_from_ports();
 }
 
 void retro_reset(void)
@@ -1502,7 +1514,20 @@ bool retro_serialize(void *data, size_t size)
 
 bool retro_unserialize(const void *data, size_t size)
 {
-   return snapshot_read_buffer(data, size, LIBSPECTRUM_ID_SNAPSHOT_SZX) == 0;
+   bool ok = snapshot_read_buffer(data, size, LIBSPECTRUM_ID_SNAPSHOT_SZX) == 0;
+
+   // Loading a snapshot re-derives settings_current.kempston_mouse from
+   // whatever was true when that particular state was captured (see
+   // kempmouse_snapshot_enabled() in fuse/peripherals/kempmouse.c) - e.g.
+   // still off, if rewound back to before the mouse was ever connected.
+   // Port wiring is live frontend state, not emulated machine state, so
+   // re-sync it from the actual current controller assignment right after
+   // every restore (rewind or manual load) rather than leaving whatever
+   // the snapshot happened to say.
+   if (ok)
+      sync_kempston_mouse_from_ports();
+
+   return ok;
 }
 
 void retro_cheat_reset(void)

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -219,6 +219,7 @@ static int show_emulation_speed_at_startup;
 static int display_joystick_type;
 static int display_emulation_speed;
 static int kempston_mouse_needs_periph_update = 0;
+static void sync_kempston_mouse_from_ports(void);
 
 static retro_video_refresh_t video_cb;
 static retro_input_poll_t input_poll_cb;
@@ -640,6 +641,16 @@ static struct retro_core_option_v2_definition core_option_definitions[] = {
          { NULL, NULL }
       },
       "500"
+   },
+   {
+      "fuse_mouse_swap_buttons",
+      "Kempston Mouse Swap Buttons",
+      NULL,
+      NULL,
+      NULL,
+      "input",
+      { CORE_OPTION_VALUE_LIST_ENABLED_DISABLED },
+      "disabled"
    },
    {
       "fuse_display_joystick_type",
@@ -1473,6 +1484,15 @@ bool retro_load_game(const struct retro_game_info *info)
 
       env_cb(RETRO_ENVIRONMENT_SET_MEMORY_MAPS, &memory_map);
 
+      // Re-apply the live controller-port wiring: if a frontend assigned
+      // RETRO_DEVICE_KEMPSTON_MOUSE before retro_load_game(), fuse_init()'s
+      // settings_defaults() has just wiped settings_current.kempston_mouse
+      // (and the deferral flag was never armed because fuse_init_called was
+      // still 0); likewise, loading snapshot content re-derives the flag
+      // from the file via kempmouse_snapshot_enabled(). Port wiring is
+      // frontend state, not machine state - see retro_unserialize().
+      sync_kempston_mouse_from_ports();
+
       return true;
    }
 
@@ -1897,6 +1917,12 @@ void retro_reset(void)
    utils_open_file(filename, 1, &type);
    display_refresh_all();
    fuse_emulation_unpause();
+
+   // If the content is a snapshot, utils_open_file() went through
+   // snapshot_copy_from() and re-derived settings_current.kempston_mouse
+   // from the file, exactly like retro_unserialize() - re-apply the live
+   // controller-port wiring here too.
+   sync_kempston_mouse_from_ports();
 }
 
 size_t retro_serialize_size(void)

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -763,8 +763,8 @@ void retro_set_environment(retro_environment_t cb)
       { "Timex 1 Joystick",    RETRO_DEVICE_TIMEX1_JOYSTICK    },
       { "Timex 2 Joystick",    RETRO_DEVICE_TIMEX2_JOYSTICK    },
       { "Fuller Joystick",     RETRO_DEVICE_FULLER_JOYSTICK    },
-      { "Sinclair Keyboard",   RETRO_DEVICE_SPECTRUM_KEYBOARD  },
-      { "Kempston Mouse",      RETRO_DEVICE_MOUSE              }
+      { "Kempston Mouse",      RETRO_DEVICE_KEMPSTON_MOUSE     },
+      { "Sinclair Keyboard",   RETRO_DEVICE_SPECTRUM_KEYBOARD  }
    };
 
    static const struct retro_controller_info ports[MAX_PADS + 1] = {
@@ -806,7 +806,7 @@ void retro_init(void)
    // (see fuse_init() -> ui_mouse_grab()); our ui_mouse_grab() stub in
    // src/compat/mouse.c always succeeds, so this keeps ui_mouse_grabbed set
    // and ui_mouse_button()/ui_mouse_motion() active whenever a port is
-   // configured as RETRO_DEVICE_MOUSE.
+   // configured as RETRO_DEVICE_KEMPSTON_MOUSE.
    ui_mouse_present = 1;
 
    // Set default controllers
@@ -1389,7 +1389,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
 
       for (p = 0; p < MAX_PADS; p++)
       {
-         if (input_devices[p] == RETRO_DEVICE_MOUSE)
+         if (input_devices[p] == RETRO_DEVICE_KEMPSTON_MOUSE)
          {
             kempston_mouse = 1;
             break;


### PR DESCRIPTION
Adds **Kempston Mouse emulation**, selectable as a device type on any of the
3 controller ports (same as the existing joysticks). The peripheral
itself (`fuse/peripherals/kempmouse.c`) was already vendored but **never
wired up to libretro**.

- New **"Kempston Mouse"** device (`RETRO_DEVICE_KEMPSTON_MOUSE`) in the
  controller port dropdown, on any port.
- New **"Kempston Mouse Swap Buttons"** core option.
- Relative mouse motion/buttons are polled every frame and forwarded
  through the same `ui_mouse_button()`/`ui_mouse_motion()` calls the
  existing UI backends already use, instead of reimplementing the logic.

Getting the peripheral to actually activate took **two iterations**: its I/O
ports need `periph_update()` to register at all (nothing else calls it when
a port assignment changes mid-session), and calling that synchronously
from `retro_set_controller_port_device()` turned out to **hang the frontend**
when RetroArch applies a saved port assignment right after content load,
before the first `retro_run()`. **Moved to the top of `retro_run()` instead**,
same as the existing model-change handling already does.

Tested against **RetroArch with a physical mouse**. Also verified that
existing per-content remaps (joystick/keyboard port assignments) resolve
unchanged - no existing device's numeric id was touched.