### PR TITLE
Fix audio clicks while Rewind is enabled

### DIFF
--- a/libspectrum/szx.c
+++ b/libspectrum/szx.c
@@ -2714,6 +2714,20 @@ libspectrum_szx_read( libspectrum_snap *snap, const libspectrum_byte *buffer,
   ctx->swap_af = 0;
 
   while( buffer < end ) {
+#ifdef __LIBRETRO__
+    /* This core pads fixed-size savestates (and auto-size states that have
+       shrunk below the frontend's frozen buffer size) with 0xFF - see
+       retro_serialize(). A pad tail of 8+ bytes is caught as the fake
+       0xFFFFFFFF chunk id inside read_chunk(), but a tail shorter than a
+       chunk header would fail read_chunk_header(); accept any all-0xFF
+       tail as clean end-of-snapshot. Chunk ids are ASCII fourCCs, so a
+       0xFF lead byte can never start a real chunk. */
+    if( *buffer == 0xFF ) {
+      const libspectrum_byte *pad = buffer;
+      while( pad < end && *pad == 0xFF ) pad++;
+      if( pad == end ) break;
+    }
+#endif
     error = read_chunk( snap, version, &buffer, end, ctx );
     if( error ) {
       libspectrum_free( ctx );

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -1382,9 +1382,7 @@ void retro_reset(void)
 size_t retro_serialize_size(void)
 {
    if (auto_size_savestate) {
-      fuse_emulation_pause();
       snapshot_update();
-      fuse_emulation_unpause();
       return snapshot_size;
    }
    else

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -1419,13 +1419,19 @@ bool retro_serialize(void *data, size_t size)
 
    if (auto_size_savestate)
    {
-      if (size <= snapshot_size)
+      if (size < snapshot_size)
       {
-         memcpy(data, snapshot_buffer, snapshot_size);
-         return true;
-      }  
-      log_cb(RETRO_LOG_WARN, "Data size is not enough for snapshot\n");
-      return false;
+         log_cb(RETRO_LOG_WARN, "Data size is not enough for snapshot\n");
+         return false;
+      }
+      memcpy(data, snapshot_buffer, snapshot_size);
+      // Frontends (rewind in particular) keep passing the size reported by
+      // the first retro_serialize_size() call even after the SZX shrinks;
+      // pad like the fixed-size path below so the tail is well-formed 0xFF
+      // instead of stale ring-buffer bytes that would parse as garbage
+      // chunks on unserialize.
+      memset(data + snapshot_size, 0xFF, size - snapshot_size);
+      return true;
    }
 
    if (size < snapshot_size)


### PR DESCRIPTION
`retro_serialize_size()` wrapped its `snapshot_update()` call in `fuse_emulation_pause()`/`fuse_emulation_unpause()`, which tears down and recreates the entire sound subsystem: `sound_pause()` -> `sound_end()` deletes the `Blip_Buffer`/`Blip_Synth` objects and their internal band-limited synthesis state, and `sound_unpause()` -> `sound_init()` reallocates all of it from scratch, discarding that state.

**RetroArch's rewind buffer calls `retro_serialize_size()` repeatedly while rewind is armed**, not just while actively scrubbing, so every poll reset the audio filter state mid-stream.

Confirmed with an instrumented build against real RetroArch:
- With Rewind enabled, every `retro_serialize_size()` call was immediately followed by one `sound_end()` + `sound_init()` cycle.
- With Rewind off, that pair only ever fired once, at startup.
- After removing the pause/unpause wrapper, the Rewind-enabled run also only produced that single startup pair.

`retro_serialize()` already calls `snapshot_update()` **without** any pause/unpause wrapper and works fine, since `retro_serialize_size()` / `retro_serialize()` are only ever called between `retro_run()` invocations in this core's single-threaded execution model - there is no concurrent Z80 execution for the pause to protect against.

**Traced the wrapper back to the very first commit** that introduced `retro_serialize_size()` in 2015, when it called the much heavier `snapshot_write()` (full file-write path) instead of today's `snapshot_update()`. It was never revisited after that function was replaced, including in a later fix for an unrelated rewind-triggered double-free (#37) in the same area. Match the existing, working `retro_serialize()` pattern instead of carrying the stale wrapper.