### PR TITLE
Add TurboSound (2x AY-8910) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The core options available on the frontend are:
 * Tape Load Sound (enabled|disabled): Outputs the tape sound if fast load is disabled
 * Speaker Type (tv speaker|beeper|unfiltered): Applies an audio filter (libretro should allow for audio filters on the frontend)
 * AY Stereo Separation (none|acb|abc): The AY sound chip stereo separation (whatever it is)
+* TurboSound (disabled|enabled): Emulates a second AY-8910 chip (classic NedoPC protocol), giving 6 sound channels instead of 3. Only used by software written for it
 * Transparent Keyboard Overlay (enabled|disabled): If the keyboard overlay is transparent or opaque
 * Time to Release Key in ms (100|300|500|1000): How much time to keep a key pressed before releasing it (used when a key is pressed using the keyboard overlay)
 

--- a/fuse/machine.h
+++ b/fuse/machine.h
@@ -81,6 +81,9 @@ typedef struct fuse_machine_info {
 						  attached to anything */
 
   ayinfo ay;		/* The AY-3-8912 chip */
+#ifdef __LIBRETRO__
+  ayinfo ay2;		/* Second AY-3-8912 chip (TurboSound) */
+#endif
 
   specdrum_info specdrum; /* SpecDrum settings */
 

--- a/fuse/peripherals/ay.c
+++ b/fuse/peripherals/ay.c
@@ -307,8 +307,12 @@ ay_from_snapshot( libspectrum_snap *snap )
   if( machine_current->capabilities & LIBSPECTRUM_MACHINE_CAPABILITY_AY ) {
     ay_state_from_snapshot( snap );
 #ifdef __LIBRETRO__
-    if( ay_turbosound_enabled && libspectrum_snap_turbosound_active( snap ) )
-      ay2_state_from_snapshot( snap );
+    /* Restored unconditionally, like chip A above, regardless of whether
+       TurboSound is currently enabled: harmless if disabled (chip B's
+       registers just sit unused - see current_ay_chip()), and safe for
+       snapshots that predate this chunk (its accessors default to zero,
+       same as any other absent chunk's fields). */
+    ay2_state_from_snapshot( snap );
 #endif
   }
 }
@@ -327,15 +331,16 @@ ay_to_snapshot( libspectrum_snap *snap )
 				       machine_current->ay.registers[i] );
 
 #ifdef __LIBRETRO__
-  if( ay_turbosound_enabled ) {
-    libspectrum_snap_set_turbosound_active( snap, 1 );
-    libspectrum_snap_set_out_ay2_registerport(
-      snap, machine_current->ay2.current_register
-    );
-    for( i = 0; i < AY_REGISTERS; i++ )
-      libspectrum_snap_set_ay2_registers( snap, i,
-                                          machine_current->ay2.registers[i] );
-  }
+  /* Written unconditionally, like chip A above - see the write side of
+     the AY2 chunk in libspectrum/szx.c for why this must not depend on
+     the (live-toggleable) ay_turbosound_enabled option. */
+  libspectrum_snap_set_turbosound_active( snap, 1 );
+  libspectrum_snap_set_out_ay2_registerport(
+    snap, machine_current->ay2.current_register
+  );
+  for( i = 0; i < AY_REGISTERS; i++ )
+    libspectrum_snap_set_ay2_registers( snap, i,
+                                        machine_current->ay2.registers[i] );
 #endif
 }
 

--- a/fuse/peripherals/ay.c
+++ b/fuse/peripherals/ay.c
@@ -290,6 +290,13 @@ ay2_state_from_snapshot( libspectrum_snap *snap )
 {
   size_t i;
 
+  /* The NedoPC chip-select latch is machine state, not synthesis state:
+     a state saved while chip B was selected must resume routing #BFFD
+     writes to chip B, or the first register batch after a load/rewind
+     lands on the wrong chip. */
+  ay_turbosound_active_chip =
+    libspectrum_snap_out_ay2_active_chip( snap ) & 1;
+
   machine_current->ay2.current_register =
     libspectrum_snap_out_ay2_registerport( snap ) & 0x0f;
 
@@ -335,6 +342,9 @@ ay_to_snapshot( libspectrum_snap *snap )
      the AY2 chunk in libspectrum/szx.c for why this must not depend on
      the (live-toggleable) ay_turbosound_enabled option. */
   libspectrum_snap_set_turbosound_active( snap, 1 );
+  libspectrum_snap_set_out_ay2_active_chip(
+    snap, (libspectrum_byte)ay_turbosound_active_chip
+  );
   libspectrum_snap_set_out_ay2_registerport(
     snap, machine_current->ay2.current_register
   );

--- a/fuse/peripherals/ay.c
+++ b/fuse/peripherals/ay.c
@@ -51,6 +51,36 @@ static void ay_to_snapshot( libspectrum_snap *snap );
 static libspectrum_dword get_current_register( void );
 static void set_current_register( libspectrum_dword value );
 
+#ifdef __LIBRETRO__
+/* TurboSound: a second AY-3-8912 chip, selected via the classic NedoPC
+   protocol - writing a value with its top 5 bits all set (0xF8-0xFF, never
+   a valid register index since a single AY only has registers 0-15) to the
+   register-select port selects the active chip instead of a register; bit 0
+   of that value picks chip A (0) or chip B (1). Everything else (register
+   read/write, port decode) is unchanged and keeps addressing whichever chip
+   is now active. Confirmed against xpeccy's TS_NEDOPC handling. */
+int ay_turbosound_enabled = 0;
+static int ay_turbosound_active_chip = 0;
+
+static int
+current_ay_chip( void )
+{
+  return ( ay_turbosound_enabled && ay_turbosound_active_chip ) ? 1 : 0;
+}
+
+static ayinfo *
+current_ay( void )
+{
+  return current_ay_chip() ? &machine_current->ay2 : &machine_current->ay;
+}
+#else
+static ayinfo *
+current_ay( void )
+{
+  return &machine_current->ay;
+}
+#endif
+
 static module_info_t ay_module_info = {
 
   /* .reset = */ ay_reset,
@@ -151,6 +181,13 @@ ay_reset( int hard_reset GCC_UNUSED )
 
   ay->current_register = 0;
   memset( ay->registers, 0, sizeof( ay->registers ) );
+
+#ifdef __LIBRETRO__
+  machine_current->ay2.current_register = 0;
+  memset( machine_current->ay2.registers, 0,
+          sizeof( machine_current->ay2.registers ) );
+  ay_turbosound_active_chip = 0;
+#endif
 }
 
 /* What happens when the AY register port (traditionally 0xfffd on the 128K
@@ -160,10 +197,11 @@ ay_registerport_read( libspectrum_word port GCC_UNUSED, libspectrum_byte *attach
 {
   int current;
   const libspectrum_byte port_input = 0xbf; /* always allow serial output */
+  ayinfo *ay = current_ay();
 
   *attached = 0xff;
 
-  current = machine_current->ay.current_register;
+  current = ay->current_register;
 
   /* The AY I/O ports return input directly from the port when in
      input mode; but in output mode, they return an AND between the
@@ -171,25 +209,31 @@ ay_registerport_read( libspectrum_word port GCC_UNUSED, libspectrum_byte *attach
      reading R14... */
 
   if( current == 14 ) {
-    if(machine_current->ay.registers[7] & 0x40)
-      return (port_input & machine_current->ay.registers[14]);
+    if(ay->registers[7] & 0x40)
+      return (port_input & ay->registers[14]);
     else
       return port_input;
   }
 
   /* R15 is simpler to do, as the 8912 lacks the second I/O port, and
      the input-mode input is always 0xff */
-  if( current == 15 && !( machine_current->ay.registers[7] & 0x80 ) )
+  if( current == 15 && !( ay->registers[7] & 0x80 ) )
     return 0xff;
 
   /* Otherwise return register value, appropriately masked */
-  return machine_current->ay.registers[ current ] & mask[ current ];
+  return ay->registers[ current ] & mask[ current ];
 }
 
 /* And when it's written to */
 void
 ay_registerport_write( libspectrum_word port GCC_UNUSED, libspectrum_byte b )
 {
+#ifdef __LIBRETRO__
+  if( ay_turbosound_enabled && ( b & 0xf8 ) == 0xf8 ) {
+    ay_turbosound_active_chip = b & 1;
+    return;
+  }
+#endif
   set_current_register( b );
 }
 
@@ -200,14 +244,25 @@ void
 ay_dataport_write( libspectrum_word port GCC_UNUSED, libspectrum_byte b )
 {
   int current;
+  ayinfo *ay = current_ay();
 
-  current = machine_current->ay.current_register;
+  current = ay->current_register;
 
-  machine_current->ay.registers[ current ] = b & mask[ current ];
+  ay->registers[ current ] = b & mask[ current ];
+#ifdef __LIBRETRO__
+  sound_ay_write( current_ay_chip(), current, b, tstates );
+  /* The .psg recording format and the serial-out port only cover a single
+     chip; only chip A's I/O port pins are wired to anything on real
+     TurboSound hardware anyway, so chip B is excluded from both. */
+  if( current_ay_chip() == 0 ) {
+    if( psg_recording ) psg_write_register( current, b );
+    if( current == 14 ) printer_serial_write( b );
+  }
+#else
   sound_ay_write( current, b, tstates );
   if( psg_recording ) psg_write_register( current, b );
-
   if( current == 14 ) printer_serial_write( b );
+#endif
 }
 
 void
@@ -221,15 +276,40 @@ ay_state_from_snapshot( libspectrum_snap *snap )
   for( i = 0; i < AY_REGISTERS; i++ ) {
     machine_current->ay.registers[i] =
       libspectrum_snap_ay_registers( snap, i );
+#ifdef __LIBRETRO__
+    sound_ay_write( 0, i, machine_current->ay.registers[i], 0 );
+#else
     sound_ay_write( i, machine_current->ay.registers[i], 0 );
+#endif
   }
 }
+
+#ifdef __LIBRETRO__
+void
+ay2_state_from_snapshot( libspectrum_snap *snap )
+{
+  size_t i;
+
+  machine_current->ay2.current_register =
+    libspectrum_snap_out_ay2_registerport( snap ) & 0x0f;
+
+  for( i = 0; i < AY_REGISTERS; i++ ) {
+    machine_current->ay2.registers[i] =
+      libspectrum_snap_ay2_registers( snap, i );
+    sound_ay_write( 1, i, machine_current->ay2.registers[i], 0 );
+  }
+}
+#endif
 
 static void
 ay_from_snapshot( libspectrum_snap *snap )
 {
   if( machine_current->capabilities & LIBSPECTRUM_MACHINE_CAPABILITY_AY ) {
     ay_state_from_snapshot( snap );
+#ifdef __LIBRETRO__
+    if( ay_turbosound_enabled && libspectrum_snap_turbosound_active( snap ) )
+      ay2_state_from_snapshot( snap );
+#endif
   }
 }
 
@@ -245,16 +325,28 @@ ay_to_snapshot( libspectrum_snap *snap )
   for( i = 0; i < AY_REGISTERS; i++ )
     libspectrum_snap_set_ay_registers( snap, i,
 				       machine_current->ay.registers[i] );
+
+#ifdef __LIBRETRO__
+  if( ay_turbosound_enabled ) {
+    libspectrum_snap_set_turbosound_active( snap, 1 );
+    libspectrum_snap_set_out_ay2_registerport(
+      snap, machine_current->ay2.current_register
+    );
+    for( i = 0; i < AY_REGISTERS; i++ )
+      libspectrum_snap_set_ay2_registers( snap, i,
+                                          machine_current->ay2.registers[i] );
+  }
+#endif
 }
 
 static libspectrum_dword
 get_current_register( void )
 {
-  return machine_current->ay.current_register;
+  return current_ay()->current_register;
 }
 
 static void
 set_current_register( libspectrum_dword value )
 {
-  machine_current->ay.current_register = (value & 0x0f);
+  current_ay()->current_register = (value & 0x0f);
 }

--- a/fuse/peripherals/ay.h
+++ b/fuse/peripherals/ay.h
@@ -43,4 +43,12 @@ void ay_dataport_write( libspectrum_word port, libspectrum_byte b );
 
 void ay_state_from_snapshot( libspectrum_snap *snap );
 
+#ifdef __LIBRETRO__
+/* TurboSound: a second AY-3-8912 chip, selected via the classic NedoPC
+   protocol (see ay.c). Controlled by a core option; off by default. */
+extern int ay_turbosound_enabled;
+
+void ay2_state_from_snapshot( libspectrum_snap *snap );
+#endif
+
 #endif			/* #ifndef FUSE_AY_H */

--- a/fuse/sound.c
+++ b/fuse/sound.c
@@ -69,13 +69,22 @@ static int sound_channels;
 
 static unsigned int ay_tone_levels[16];
 
-static unsigned int ay_tone_tick[3], ay_tone_high[3], ay_noise_tick;
-static unsigned int ay_tone_cycles, ay_env_cycles;
-static unsigned int ay_env_internal_tick, ay_env_tick;
-static unsigned int ay_tone_period[3], ay_noise_period, ay_env_period;
+/* TurboSound: chip index 0 is the machine's own AY chip, index 1 is
+   TurboSound's second chip (only driven when ay_turbosound_enabled). */
+#define TS_CHIPS 2
+
+static unsigned int ay_tone_tick[TS_CHIPS][3], ay_tone_high[TS_CHIPS][3],
+                     ay_noise_tick[TS_CHIPS];
+static unsigned int ay_tone_cycles[TS_CHIPS], ay_env_cycles[TS_CHIPS];
+static unsigned int ay_env_internal_tick[TS_CHIPS], ay_env_tick[TS_CHIPS];
+static unsigned int ay_tone_period[TS_CHIPS][3], ay_noise_period[TS_CHIPS],
+                     ay_env_period[TS_CHIPS];
+static int ay_rng[TS_CHIPS];
+static int ay_noise_toggle[TS_CHIPS];
+static int ay_env_first[TS_CHIPS], ay_env_rev[TS_CHIPS], ay_env_counter[TS_CHIPS];
 
 /* Local copy of the AY registers */
-static libspectrum_byte sound_ay_registers[16];
+static libspectrum_byte sound_ay_registers[TS_CHIPS][16];
 
 struct ay_change_tag
 {
@@ -83,8 +92,8 @@ struct ay_change_tag
   unsigned char reg, val;
 };
 
-static struct ay_change_tag ay_change[ AY_CHANGE_MAX ];
-static int ay_change_count;
+static struct ay_change_tag ay_change[TS_CHIPS][ AY_CHANGE_MAX ];
+static int ay_change_count[TS_CHIPS];
 
 Blip_Buffer *left_buf = NULL;
 Blip_Buffer *right_buf = NULL;
@@ -94,6 +103,11 @@ Blip_Synth *left_beeper_synth = NULL, *right_beeper_synth = NULL;
 
 Blip_Synth *ay_a_synth = NULL, *ay_b_synth = NULL, *ay_c_synth = NULL;
 Blip_Synth *ay_a_synth_r = NULL, *ay_b_synth_r = NULL, *ay_c_synth_r = NULL;
+
+/* TurboSound: second chip's synths, wired up identically to the above and
+   only ever driven when ay_turbosound_enabled is set. */
+Blip_Synth *ts_ay_a_synth = NULL, *ts_ay_b_synth = NULL, *ts_ay_c_synth = NULL;
+Blip_Synth *ts_ay_a_synth_r = NULL, *ts_ay_b_synth_r = NULL, *ts_ay_c_synth_r = NULL;
 
 Blip_Synth *left_specdrum_synth = NULL, *right_specdrum_synth = NULL;
 
@@ -151,7 +165,7 @@ sound_init_blip( Blip_Buffer **buf, Blip_Synth **synth )
 }
 
 static void
-sound_ay_init( void )
+sound_ay_init( int chip )
 {
   /* AY output doesn't match the claimed levels; these levels are based
    * on the measurements posted to comp.sys.sinclair in Dec 2001 by
@@ -170,13 +184,19 @@ sound_ay_init( void )
   for( f = 0; f < 16; f++ )
     ay_tone_levels[f] = ( levels[f] * AMPL_AY_TONE + 0x8000 ) / 0xffff;
 
-  ay_noise_tick = ay_noise_period = 0;
-  ay_env_internal_tick = ay_env_tick = ay_env_period = 0;
-  ay_tone_cycles = ay_env_cycles = 0;
+  ay_noise_tick[chip] = ay_noise_period[chip] = 0;
+  ay_env_internal_tick[chip] = ay_env_tick[chip] = ay_env_period[chip] = 0;
+  ay_tone_cycles[chip] = ay_env_cycles[chip] = 0;
   for( f = 0; f < 3; f++ )
-    ay_tone_tick[f] = ay_tone_high[f] = 0, ay_tone_period[f] = 1;
+    ay_tone_tick[chip][f] = ay_tone_high[chip][f] = 0, ay_tone_period[chip][f] = 1;
 
-  ay_change_count = 0;
+  ay_rng[chip] = 1;
+  ay_noise_toggle[chip] = 0;
+  ay_env_first[chip] = 1;
+  ay_env_rev[chip] = 0;
+  ay_env_counter[chip] = 15;
+
+  ay_change_count[chip] = 0;
 }
 
 #ifndef UI_WIN32
@@ -196,15 +216,77 @@ is_in_sound_enabled_range( void )
     settings_current.emulation_speed <= MAX_SPEED_PERCENTAGE;
 }
 
+/* Set up (volume/treble/output routing) one AY chip's three tone
+   Blip_Synths. Used for both the machine's own AY chip and, when
+   TurboSound is enabled, the second chip. */
+static void
+sound_init_ay_synths( Blip_Synth **a_synth, Blip_Synth **b_synth,
+                       Blip_Synth **c_synth, Blip_Synth **a_synth_r,
+                       Blip_Synth **b_synth_r, Blip_Synth **c_synth_r,
+                       double treble )
+{
+  Blip_Synth **left_synth, **mid_synth, **mid_synth_r, **right_synth;
+
+  *a_synth = new_Blip_Synth();
+  blip_synth_set_volume( *a_synth, sound_get_volume( settings_current.volume_ay ) );
+  blip_synth_set_treble_eq( *a_synth, treble );
+
+  *b_synth = new_Blip_Synth();
+  blip_synth_set_volume( *b_synth, sound_get_volume( settings_current.volume_ay ) );
+  blip_synth_set_treble_eq( *b_synth, treble );
+
+  *c_synth = new_Blip_Synth();
+  blip_synth_set_volume( *c_synth, sound_get_volume( settings_current.volume_ay ) );
+  blip_synth_set_treble_eq( *c_synth, treble );
+
+  /* important to override these settings if not using stereo
+   * (it would probably be confusing to mess with the stereo
+   * settings in settings_current though, which is why we make copies
+   * rather than using the real ones).
+   */
+  *a_synth_r = NULL;
+  *b_synth_r = NULL;
+  *c_synth_r = NULL;
+
+  if( sound_stereo_ay != SOUND_STEREO_AY_NONE ) {
+    /* Attach the Blip_Synth's we've already created as appropriate, and
+     * create one more Blip_Synth for the middle channel's right buffer. */
+    if( sound_stereo_ay == SOUND_STEREO_AY_ACB ) {
+      left_synth = a_synth;
+      mid_synth = c_synth;
+      mid_synth_r = c_synth_r;
+      right_synth = b_synth;
+    } else if ( sound_stereo_ay == SOUND_STEREO_AY_ABC ) {
+      left_synth = a_synth;
+      mid_synth = b_synth;
+      mid_synth_r = b_synth_r;
+      right_synth = c_synth;
+    } else {
+      ui_error( UI_ERROR_ERROR, "unknown AY stereo separation type: %d", sound_stereo_ay );
+      fuse_abort();
+    }
+
+    blip_synth_set_output( *left_synth, left_buf );
+    blip_synth_set_output( *mid_synth, left_buf );
+    blip_synth_set_output( *right_synth, right_buf );
+
+    *mid_synth_r = new_Blip_Synth();
+    blip_synth_set_volume( *mid_synth_r,
+                           sound_get_volume( settings_current.volume_ay ) );
+    blip_synth_set_output( *mid_synth_r, right_buf );
+    blip_synth_set_treble_eq( *mid_synth_r, treble );
+  } else {
+    blip_synth_set_output( *a_synth, left_buf );
+    blip_synth_set_output( *b_synth, left_buf );
+    blip_synth_set_output( *c_synth, left_buf );
+  }
+}
+
 void
 sound_init( const char *device )
 {
   float hz;
   double treble;
-  Blip_Synth **ay_left_synth;
-  Blip_Synth **ay_mid_synth;
-  Blip_Synth **ay_mid_synth_r;
-  Blip_Synth **ay_right_synth;
 
   /* Allow sound as long as emulation speed is greater than 2%
      (less than that and a single Speccy frame generates more
@@ -229,20 +311,11 @@ sound_init( const char *device )
 
   treble = speaker_type[ option_enumerate_sound_speaker_type() ].treble;
 
-  ay_a_synth = new_Blip_Synth();
-  blip_synth_set_volume( ay_a_synth,
-                         sound_get_volume( settings_current.volume_ay) );
-  blip_synth_set_treble_eq( ay_a_synth, treble );
-
-  ay_b_synth = new_Blip_Synth();
-  blip_synth_set_volume( ay_b_synth,
-                         sound_get_volume( settings_current.volume_ay) );
-  blip_synth_set_treble_eq( ay_b_synth, treble );
-
-  ay_c_synth = new_Blip_Synth();
-  blip_synth_set_volume( ay_c_synth,
-                         sound_get_volume( settings_current.volume_ay) );
-  blip_synth_set_treble_eq( ay_c_synth, treble );
+  sound_init_ay_synths( &ay_a_synth, &ay_b_synth, &ay_c_synth,
+                         &ay_a_synth_r, &ay_b_synth_r, &ay_c_synth_r, treble );
+  sound_init_ay_synths( &ts_ay_a_synth, &ts_ay_b_synth, &ts_ay_c_synth,
+                         &ts_ay_a_synth_r, &ts_ay_b_synth_r, &ts_ay_c_synth_r,
+                         treble );
 
   left_specdrum_synth = new_Blip_Synth();
   blip_synth_set_volume( left_specdrum_synth,
@@ -255,45 +328,8 @@ sound_init( const char *device )
                          sound_get_volume( settings_current.volume_covox ) );
   blip_synth_set_output( left_covox_synth, left_buf );
   blip_synth_set_treble_eq( left_covox_synth, treble );
-  
-  /* important to override these settings if not using stereo
-   * (it would probably be confusing to mess with the stereo
-   * settings in settings_current though, which is why we make copies
-   * rather than using the real ones).
-   */
-
-  ay_a_synth_r = NULL;
-  ay_b_synth_r = NULL;
-  ay_c_synth_r = NULL;
 
   if( sound_stereo_ay != SOUND_STEREO_AY_NONE ) {
-    /* Attach the Blip_Synth's we've already created as appropriate, and
-     * create one more Blip_Synth for the middle channel's right buffer. */
-    if( sound_stereo_ay == SOUND_STEREO_AY_ACB ) {
-      ay_left_synth = &ay_a_synth;
-      ay_mid_synth = &ay_c_synth;
-      ay_mid_synth_r = &ay_c_synth_r;
-      ay_right_synth = &ay_b_synth;
-    } else if ( sound_stereo_ay == SOUND_STEREO_AY_ABC ) {
-      ay_left_synth = &ay_a_synth;
-      ay_mid_synth = &ay_b_synth;
-      ay_mid_synth_r = &ay_b_synth_r;
-      ay_right_synth = &ay_c_synth;
-    } else {
-      ui_error( UI_ERROR_ERROR, "unknown AY stereo separation type: %d", sound_stereo_ay );
-      fuse_abort();
-    }
-
-    blip_synth_set_output( *ay_left_synth, left_buf );
-    blip_synth_set_output( *ay_mid_synth, left_buf );
-    blip_synth_set_output( *ay_right_synth, right_buf );
-
-    *ay_mid_synth_r = new_Blip_Synth();
-    blip_synth_set_volume( *ay_mid_synth_r,
-                           sound_get_volume( settings_current.volume_ay ) );
-    blip_synth_set_output( *ay_mid_synth_r, right_buf );
-    blip_synth_set_treble_eq( *ay_mid_synth_r, treble );
-
     right_specdrum_synth = new_Blip_Synth();
     blip_synth_set_volume( right_specdrum_synth,
                            sound_get_volume( settings_current.volume_specdrum ) );
@@ -305,10 +341,6 @@ sound_init( const char *device )
                            sound_get_volume( settings_current.volume_covox ) );
     blip_synth_set_output( right_covox_synth, right_buf );
     blip_synth_set_treble_eq( right_covox_synth, treble );
-  } else {
-    blip_synth_set_output( ay_a_synth, left_buf );
-    blip_synth_set_output( ay_b_synth, left_buf );
-    blip_synth_set_output( ay_c_synth, left_buf );
   }
 
   sound_enabled = sound_enabled_ever = 1;
@@ -363,6 +395,13 @@ sound_end( void )
     delete_Blip_Synth( &ay_b_synth_r );
     delete_Blip_Synth( &ay_c_synth_r );
 
+    delete_Blip_Synth( &ts_ay_a_synth );
+    delete_Blip_Synth( &ts_ay_b_synth );
+    delete_Blip_Synth( &ts_ay_c_synth );
+    delete_Blip_Synth( &ts_ay_a_synth_r );
+    delete_Blip_Synth( &ts_ay_b_synth_r );
+    delete_Blip_Synth( &ts_ay_c_synth_r );
+
     delete_Blip_Synth( &left_specdrum_synth );
     delete_Blip_Synth( &right_specdrum_synth );
 
@@ -388,19 +427,19 @@ sound_register_startup( void )
 }
 
 static inline void
-ay_do_tone( int level, unsigned int tone_count, int *var, int chan )
+ay_do_tone( int chip, int level, unsigned int tone_count, int *var, int chan )
 {
   *var = 0;
 
-  ay_tone_tick[ chan ] += tone_count;
+  ay_tone_tick[ chip ][ chan ] += tone_count;
 
-  if( ay_tone_tick[ chan ] >= ay_tone_period[ chan ] ) {
-    ay_tone_tick[ chan ] -= ay_tone_period[ chan ];
-    ay_tone_high[ chan ] = !ay_tone_high[ chan ];
+  if( ay_tone_tick[ chip ][ chan ] >= ay_tone_period[ chip ][ chan ] ) {
+    ay_tone_tick[ chip ][ chan ] -= ay_tone_period[ chip ][ chan ];
+    ay_tone_high[ chip ][ chan ] = !ay_tone_high[ chip ][ chan ];
   }
 
   if( level ) {
-    if( ay_tone_high[ chan ] )
+    if( ay_tone_high[ chip ][ chan ] )
       *var = level;
     else {
       *var = 0;
@@ -422,21 +461,20 @@ ay_do_tone( int level, unsigned int tone_count, int *var, int chan )
 #define AY_CLOCK_RATIO 2
 
 static void
-sound_ay_overlay( void )
+sound_ay_overlay( int chip )
 {
-  static int rng = 1;
-  static int noise_toggle = 0;
-  static int env_first = 1, env_rev = 0, env_counter = 15;
   int tone_level[3];
   int mixer, envshape;
   int g, level;
   libspectrum_dword f;
-  struct ay_change_tag *change_ptr = ay_change;
-  int changes_left = ay_change_count;
+  struct ay_change_tag *change_ptr = ay_change[ chip ];
+  int changes_left = ay_change_count[ chip ];
   int reg, r;
   int chan1, chan2, chan3;
   int last_chan1 = 0, last_chan2 = 0, last_chan3 = 0;
   unsigned int tone_count, noise_count;
+  Blip_Synth *a_synth, *b_synth, *c_synth;
+  Blip_Synth *a_synth_r, *b_synth_r, *c_synth_r;
 
   /* If no AY chip, don't produce any AY sound (!) */
   if( !( periph_is_active( PERIPH_TYPE_FULLER) ||
@@ -444,11 +482,19 @@ sound_ay_overlay( void )
          machine_current->capabilities & LIBSPECTRUM_MACHINE_CAPABILITY_AY ) )
     return;
 
+  if( chip == 0 ) {
+    a_synth = ay_a_synth; b_synth = ay_b_synth; c_synth = ay_c_synth;
+    a_synth_r = ay_a_synth_r; b_synth_r = ay_b_synth_r; c_synth_r = ay_c_synth_r;
+  } else {
+    a_synth = ts_ay_a_synth; b_synth = ts_ay_b_synth; c_synth = ts_ay_c_synth;
+    a_synth_r = ts_ay_a_synth_r; b_synth_r = ts_ay_b_synth_r; c_synth_r = ts_ay_c_synth_r;
+  }
+
   for( f = 0; f < machine_current->timings.tstates_per_frame;
        f+= AY_CLOCK_DIVISOR * AY_CLOCK_RATIO ) {
     /* update ay registers. */
     while( changes_left && f >= change_ptr->tstates ) {
-      sound_ay_registers[ reg = change_ptr->reg ] = change_ptr->val;
+      sound_ay_registers[ chip ][ reg = change_ptr->reg ] = change_ptr->val;
       change_ptr++;
       changes_left--;
 
@@ -457,94 +503,94 @@ sound_ay_overlay( void )
       case 0: case 1: case 2: case 3: case 4: case 5:
         r = reg >> 1;
         /* a zero-len period is the same as 1 */
-        ay_tone_period[r] = ( sound_ay_registers[ reg & ~1 ] |
-                              ( sound_ay_registers[ reg | 1 ] & 15 ) << 8 );
-        if( !ay_tone_period[r] )
-          ay_tone_period[r]++;
+        ay_tone_period[ chip ][r] = ( sound_ay_registers[ chip ][ reg & ~1 ] |
+                              ( sound_ay_registers[ chip ][ reg | 1 ] & 15 ) << 8 );
+        if( !ay_tone_period[ chip ][r] )
+          ay_tone_period[ chip ][r]++;
 
         /* important to get this right, otherwise e.g. Ghouls 'n' Ghosts
          * has really scratchy, horrible-sounding vibrato.
          */
-        if( ay_tone_tick[r] >= ay_tone_period[r] * 2 )
-          ay_tone_tick[r] %= ay_tone_period[r] * 2;
+        if( ay_tone_tick[ chip ][r] >= ay_tone_period[ chip ][r] * 2 )
+          ay_tone_tick[ chip ][r] %= ay_tone_period[ chip ][r] * 2;
         break;
       case 6:
-        ay_noise_tick = 0;
-        ay_noise_period = ( sound_ay_registers[ reg ] & 31 );
+        ay_noise_tick[ chip ] = 0;
+        ay_noise_period[ chip ] = ( sound_ay_registers[ chip ][ reg ] & 31 );
         break;
       case 11: case 12:
-        ay_env_period =
-          sound_ay_registers[11] | ( sound_ay_registers[12] << 8 );
+        ay_env_period[ chip ] =
+          sound_ay_registers[ chip ][11] | ( sound_ay_registers[ chip ][12] << 8 );
         break;
       case 13:
-        ay_env_internal_tick = ay_env_tick = ay_env_cycles = 0;
-        env_first = 1;
-        env_rev = 0;
-        env_counter = ( sound_ay_registers[13] & AY_ENV_ATTACK ) ? 0 : 15;
+        ay_env_internal_tick[ chip ] = ay_env_tick[ chip ] = ay_env_cycles[ chip ] = 0;
+        ay_env_first[ chip ] = 1;
+        ay_env_rev[ chip ] = 0;
+        ay_env_counter[ chip ] = ( sound_ay_registers[ chip ][13] & AY_ENV_ATTACK ) ? 0 : 15;
         break;
       }
     }
 
     /* the tone level if no enveloping is being used */
     for( g = 0; g < 3; g++ )
-      tone_level[g] = ay_tone_levels[ sound_ay_registers[ 8 + g ] & 15 ];
+      tone_level[g] = ay_tone_levels[ sound_ay_registers[ chip ][ 8 + g ] & 15 ];
 
     /* envelope */
-    envshape = sound_ay_registers[13];
-    level = ay_tone_levels[ env_counter ];
+    envshape = sound_ay_registers[ chip ][13];
+    level = ay_tone_levels[ ay_env_counter[ chip ] ];
 
     for( g = 0; g < 3; g++ )
-      if( sound_ay_registers[ 8 + g ] & 16 )
+      if( sound_ay_registers[ chip ][ 8 + g ] & 16 )
         tone_level[g] = level;
 
     /* envelope output counter gets incr'd every 16 AY cycles. */
-    ay_env_cycles += AY_CLOCK_DIVISOR;
+    ay_env_cycles[ chip ] += AY_CLOCK_DIVISOR;
     noise_count = 0;
-    while( ay_env_cycles >= 16 ) {
-      ay_env_cycles -= 16;
+    while( ay_env_cycles[ chip ] >= 16 ) {
+      ay_env_cycles[ chip ] -= 16;
       noise_count++;
-      ay_env_tick++;
-      while( ay_env_tick >= ay_env_period ) {
-        ay_env_tick -= ay_env_period;
+      ay_env_tick[ chip ]++;
+      while( ay_env_tick[ chip ] >= ay_env_period[ chip ] ) {
+        ay_env_tick[ chip ] -= ay_env_period[ chip ];
 
         /* do a 1/16th-of-period incr/decr if needed */
-        if( env_first ||
+        if( ay_env_first[ chip ] ||
             ( ( envshape & AY_ENV_CONT ) && !( envshape & AY_ENV_HOLD ) ) ) {
-          if( env_rev )
-            env_counter -= ( envshape & AY_ENV_ATTACK ) ? 1 : -1;
+          if( ay_env_rev[ chip ] )
+            ay_env_counter[ chip ] -= ( envshape & AY_ENV_ATTACK ) ? 1 : -1;
           else
-            env_counter += ( envshape & AY_ENV_ATTACK ) ? 1 : -1;
-          if( env_counter < 0 )
-            env_counter = 0;
-          if( env_counter > 15 )
-            env_counter = 15;
+            ay_env_counter[ chip ] += ( envshape & AY_ENV_ATTACK ) ? 1 : -1;
+          if( ay_env_counter[ chip ] < 0 )
+            ay_env_counter[ chip ] = 0;
+          if( ay_env_counter[ chip ] > 15 )
+            ay_env_counter[ chip ] = 15;
         }
 
-        ay_env_internal_tick++;
-        while( ay_env_internal_tick >= 16 ) {
-          ay_env_internal_tick -= 16;
+        ay_env_internal_tick[ chip ]++;
+        while( ay_env_internal_tick[ chip ] >= 16 ) {
+          ay_env_internal_tick[ chip ] -= 16;
 
           /* end of cycle */
           if( !( envshape & AY_ENV_CONT ) )
-            env_counter = 0;
+            ay_env_counter[ chip ] = 0;
           else {
             if( envshape & AY_ENV_HOLD ) {
-              if( env_first && ( envshape & AY_ENV_ALT ) )
-                env_counter = ( env_counter ? 0 : 15 );
+              if( ay_env_first[ chip ] && ( envshape & AY_ENV_ALT ) )
+                ay_env_counter[ chip ] = ( ay_env_counter[ chip ] ? 0 : 15 );
             } else {
               /* non-hold */
               if( envshape & AY_ENV_ALT )
-                env_rev = !env_rev;
+                ay_env_rev[ chip ] = !ay_env_rev[ chip ];
               else
-                env_counter = ( envshape & AY_ENV_ATTACK ) ? 0 : 15;
+                ay_env_counter[ chip ] = ( envshape & AY_ENV_ATTACK ) ? 0 : 15;
             }
           }
 
-          env_first = 0;
+          ay_env_first[ chip ] = 0;
         }
 
         /* don't keep trying if period is zero */
-        if( !ay_env_period )
+        if( !ay_env_period[ chip ] )
           break;
       }
     }
@@ -557,67 +603,67 @@ sound_ay_overlay( void )
     chan1 = tone_level[0];
     chan2 = tone_level[1];
     chan3 = tone_level[2];
-    mixer = sound_ay_registers[7];
+    mixer = sound_ay_registers[ chip ][7];
 
-    ay_tone_cycles += AY_CLOCK_DIVISOR;
-    tone_count = ay_tone_cycles >> 3;
-    ay_tone_cycles &= 7;
+    ay_tone_cycles[ chip ] += AY_CLOCK_DIVISOR;
+    tone_count = ay_tone_cycles[ chip ] >> 3;
+    ay_tone_cycles[ chip ] &= 7;
 
     if( ( mixer & 1 ) == 0 ) {
       level = chan1;
-      ay_do_tone( level, tone_count, &chan1, 0 );
+      ay_do_tone( chip, level, tone_count, &chan1, 0 );
     }
-    if( ( mixer & 0x08 ) == 0 && noise_toggle )
+    if( ( mixer & 0x08 ) == 0 && ay_noise_toggle[ chip ] )
       chan1 = 0;
 
     if( ( mixer & 2 ) == 0 ) {
       level = chan2;
-      ay_do_tone( level, tone_count, &chan2, 1 );
+      ay_do_tone( chip, level, tone_count, &chan2, 1 );
     }
-    if( ( mixer & 0x10 ) == 0 && noise_toggle )
+    if( ( mixer & 0x10 ) == 0 && ay_noise_toggle[ chip ] )
       chan2 = 0;
 
     if( ( mixer & 4 ) == 0 ) {
       level = chan3;
-      ay_do_tone( level, tone_count, &chan3, 2 );
+      ay_do_tone( chip, level, tone_count, &chan3, 2 );
     }
-    if( ( mixer & 0x20 ) == 0 && noise_toggle )
+    if( ( mixer & 0x20 ) == 0 && ay_noise_toggle[ chip ] )
       chan3 = 0;
 
     if( last_chan1 != chan1 ) {
-      blip_synth_update( ay_a_synth, f, chan1 );
-      if( ay_a_synth_r ) blip_synth_update( ay_a_synth_r, f, chan1 );
+      blip_synth_update( a_synth, f, chan1 );
+      if( a_synth_r ) blip_synth_update( a_synth_r, f, chan1 );
       last_chan1 = chan1;
     }
     if( last_chan2 != chan2 ) {
-      blip_synth_update( ay_b_synth, f, chan2 );
-      if( ay_b_synth_r ) blip_synth_update( ay_b_synth_r, f, chan2 );
+      blip_synth_update( b_synth, f, chan2 );
+      if( b_synth_r ) blip_synth_update( b_synth_r, f, chan2 );
       last_chan2 = chan2;
     }
     if( last_chan3 != chan3 ) {
-      blip_synth_update( ay_c_synth, f, chan3 );
-      if( ay_c_synth_r ) blip_synth_update( ay_c_synth_r, f, chan3 );
+      blip_synth_update( c_synth, f, chan3 );
+      if( c_synth_r ) blip_synth_update( c_synth_r, f, chan3 );
       last_chan3 = chan3;
     }
 
     /* update noise RNG/filter */
-    ay_noise_tick += noise_count;
-    while( ay_noise_tick >= ay_noise_period ) {
-      ay_noise_tick -= ay_noise_period;
+    ay_noise_tick[ chip ] += noise_count;
+    while( ay_noise_tick[ chip ] >= ay_noise_period[ chip ] ) {
+      ay_noise_tick[ chip ] -= ay_noise_period[ chip ];
 
-      if( ( rng & 1 ) ^ ( ( rng & 2 ) ? 1 : 0 ) )
-        noise_toggle = !noise_toggle;
+      if( ( ay_rng[ chip ] & 1 ) ^ ( ( ay_rng[ chip ] & 2 ) ? 1 : 0 ) )
+        ay_noise_toggle[ chip ] = !ay_noise_toggle[ chip ];
 
       /* rng is 17-bit shift reg, bit 0 is output.
        * input is bit 0 xor bit 3.
        */
-      if( rng & 1 ) {
-        rng ^= 0x24000;
+      if( ay_rng[ chip ] & 1 ) {
+        ay_rng[ chip ] ^= 0x24000;
       }
-      rng >>= 1;
+      ay_rng[ chip ] >>= 1;
 
       /* don't keep trying if period is zero */
-      if( !ay_noise_period )
+      if( !ay_noise_period[ chip ] )
         break;
     }
   }
@@ -627,13 +673,13 @@ sound_ay_overlay( void )
  * to be made by sound_frame() (via sound_ay_overlay()).
  */
 void
-sound_ay_write( int reg, int val, libspectrum_dword now )
+sound_ay_write( int chip, int reg, int val, libspectrum_dword now )
 {
-  if( ay_change_count < AY_CHANGE_MAX ) {
-    ay_change[ ay_change_count ].tstates = now;
-    ay_change[ ay_change_count ].reg = ( reg & 15 );
-    ay_change[ ay_change_count ].val = val;
-    ay_change_count++;
+  if( ay_change_count[ chip ] < AY_CHANGE_MAX ) {
+    ay_change[ chip ][ ay_change_count[ chip ] ].tstates = now;
+    ay_change[ chip ][ ay_change_count[ chip ] ].reg = ( reg & 15 );
+    ay_change[ chip ][ ay_change_count[ chip ] ].val = val;
+    ay_change_count[ chip ]++;
   }
 }
 
@@ -643,17 +689,19 @@ sound_ay_write( int reg, int val, libspectrum_dword now )
 void
 sound_ay_reset( void )
 {
-  int f;
+  int f, chip;
 
-  /* recalculate timings based on new machines ay clock */
-  sound_ay_init();
+  for( chip = 0; chip < TS_CHIPS; chip++ ) {
+    /* recalculate timings based on new machines ay clock */
+    sound_ay_init( chip );
 
-  ay_change_count = 0;
-  for( f = 0; f < 16; f++ )
-    sound_ay_write( f, 0, 0 );
-  for( f = 0; f < 3; f++ )
-    ay_tone_high[f] = 0;
-  ay_tone_cycles = ay_env_cycles = 0;
+    ay_change_count[ chip ] = 0;
+    for( f = 0; f < 16; f++ )
+      sound_ay_write( chip, f, 0, 0 );
+    for( f = 0; f < 3; f++ )
+      ay_tone_high[ chip ][f] = 0;
+    ay_tone_cycles[ chip ] = ay_env_cycles[ chip ] = 0;
+  }
 }
 
 /*
@@ -698,7 +746,9 @@ sound_frame( void )
     return;
 
   /* overlay AY sound */
-  sound_ay_overlay();
+  sound_ay_overlay( 0 );
+  if( ay_turbosound_enabled )
+    sound_ay_overlay( 1 );
 
   blip_buffer_end_frame( left_buf, machine_current->timings.tstates_per_frame );
 
@@ -725,7 +775,7 @@ sound_frame( void )
 
   if( movie_recording )
       movie_add_sound( samples, count );
-  ay_change_count = 0;
+  ay_change_count[0] = ay_change_count[1] = 0;
 }
 
 void

--- a/fuse/sound.h
+++ b/fuse/sound.h
@@ -33,7 +33,7 @@ void sound_init( const char *device );
 void sound_pause( void );
 void sound_unpause( void );
 void sound_end( void );
-void sound_ay_write( int reg, int val, libspectrum_dword now );
+void sound_ay_write( int chip, int reg, int val, libspectrum_dword now );
 void sound_ay_reset( void );
 void sound_specdrum_write( libspectrum_word port, libspectrum_byte val );
 void sound_covox_write( libspectrum_word port, libspectrum_byte val );

--- a/libspectrum/snap_accessors.c
+++ b/libspectrum/snap_accessors.c
@@ -80,6 +80,13 @@ struct libspectrum_snap {
   libspectrum_byte out_ay_registerport;
   libspectrum_byte ay_registers[ 16 ];
 
+#ifdef __LIBRETRO__
+  /* TurboSound: second AY-3-8912 chip */
+  int turbosound_active;
+  libspectrum_byte out_ay2_registerport;
+  libspectrum_byte ay2_registers[ 16 ];
+#endif
+
   /* Timex-specific bits */
   libspectrum_byte out_scld_hsr;
   libspectrum_byte out_scld_dec;
@@ -367,6 +374,14 @@ libspectrum_snap_alloc( void )
   libspectrum_snap_set_out_ay_registerport( snap, 0x0e );
   for( i = 0; i < 16; i++ )
     libspectrum_snap_set_ay_registers( snap, i, 0 );
+
+#ifdef __LIBRETRO__
+  /* TurboSound: second AY-3-8912 chip */
+  libspectrum_snap_set_turbosound_active( snap, 0 );
+  libspectrum_snap_set_out_ay2_registerport( snap, 0 );
+  for( i = 0; i < 16; i++ )
+    libspectrum_snap_set_ay2_registers( snap, i, 0 );
+#endif
 
   /* Timex-specific bits */
   libspectrum_snap_set_out_scld_hsr( snap, 0 );
@@ -1138,6 +1153,46 @@ libspectrum_snap_set_ay_registers( libspectrum_snap *snap, int idx, libspectrum_
 {
   snap->ay_registers[idx] = ay_registers;
 }
+
+#ifdef __LIBRETRO__
+
+int
+libspectrum_snap_turbosound_active( libspectrum_snap *snap )
+{
+  return snap->turbosound_active;
+}
+
+void
+libspectrum_snap_set_turbosound_active( libspectrum_snap *snap, int turbosound_active )
+{
+  snap->turbosound_active = turbosound_active;
+}
+
+libspectrum_byte
+libspectrum_snap_out_ay2_registerport( libspectrum_snap *snap )
+{
+  return snap->out_ay2_registerport;
+}
+
+void
+libspectrum_snap_set_out_ay2_registerport( libspectrum_snap *snap, libspectrum_byte out_ay2_registerport )
+{
+  snap->out_ay2_registerport = out_ay2_registerport;
+}
+
+libspectrum_byte
+libspectrum_snap_ay2_registers( libspectrum_snap *snap, int idx )
+{
+  return snap->ay2_registers[idx];
+}
+
+void
+libspectrum_snap_set_ay2_registers( libspectrum_snap *snap, int idx, libspectrum_byte ay2_registers )
+{
+  snap->ay2_registers[idx] = ay2_registers;
+}
+
+#endif /* #ifdef __LIBRETRO__ */
 
 libspectrum_byte
 libspectrum_snap_out_scld_hsr( libspectrum_snap *snap )

--- a/libspectrum/snap_accessors.c
+++ b/libspectrum/snap_accessors.c
@@ -85,6 +85,7 @@ struct libspectrum_snap {
   int turbosound_active;
   libspectrum_byte out_ay2_registerport;
   libspectrum_byte ay2_registers[ 16 ];
+  libspectrum_byte out_ay2_active_chip;
 #endif
 
   /* Timex-specific bits */
@@ -381,6 +382,7 @@ libspectrum_snap_alloc( void )
   libspectrum_snap_set_out_ay2_registerport( snap, 0 );
   for( i = 0; i < 16; i++ )
     libspectrum_snap_set_ay2_registers( snap, i, 0 );
+  libspectrum_snap_set_out_ay2_active_chip( snap, 0 );
 #endif
 
   /* Timex-specific bits */
@@ -1190,6 +1192,18 @@ void
 libspectrum_snap_set_ay2_registers( libspectrum_snap *snap, int idx, libspectrum_byte ay2_registers )
 {
   snap->ay2_registers[idx] = ay2_registers;
+}
+
+libspectrum_byte
+libspectrum_snap_out_ay2_active_chip( libspectrum_snap *snap )
+{
+  return snap->out_ay2_active_chip;
+}
+
+void
+libspectrum_snap_set_out_ay2_active_chip( libspectrum_snap *snap, libspectrum_byte out_ay2_active_chip )
+{
+  snap->out_ay2_active_chip = out_ay2_active_chip;
 }
 
 #endif /* #ifdef __LIBRETRO__ */

--- a/libspectrum/snap_accessors.txt
+++ b/libspectrum/snap_accessors.txt
@@ -80,6 +80,11 @@ libspectrum_byte out_plus3_memoryport 0 0x08 /* Used for both the +3's and the S
 libspectrum_byte out_ay_registerport 0 0x0e
 libspectrum_byte ay_registers 16
 
+/* TurboSound: second AY-3-8912 chip (fuse-libretro only) */
+int turbosound_active
+libspectrum_byte out_ay2_registerport
+libspectrum_byte ay2_registers 16
+
 /* Timex-specific bits */
 libspectrum_byte out_scld_hsr
 libspectrum_byte out_scld_dec

--- a/libspectrum/snap_accessors.txt
+++ b/libspectrum/snap_accessors.txt
@@ -84,6 +84,7 @@ libspectrum_byte ay_registers 16
 int turbosound_active
 libspectrum_byte out_ay2_registerport
 libspectrum_byte ay2_registers 16
+libspectrum_byte out_ay2_active_chip
 
 /* Timex-specific bits */
 libspectrum_byte out_scld_hsr

--- a/libspectrum/szx.c
+++ b/libspectrum/szx.c
@@ -517,7 +517,7 @@ read_ay2_chunk( libspectrum_snap *snap, libspectrum_word version GCC_UNUSED,
 {
   size_t i;
 
-  if( data_length != 17 ) {
+  if( data_length != 18 ) {
     libspectrum_print_error( LIBSPECTRUM_ERROR_UNKNOWN,
 			     "szx_read_ay2_chunk: unknown length %lu",
 			     (unsigned long)data_length );
@@ -525,6 +525,9 @@ read_ay2_chunk( libspectrum_snap *snap, libspectrum_word version GCC_UNUSED,
   }
 
   libspectrum_snap_set_turbosound_active( snap, 1 );
+
+  /* Which chip the NedoPC select latch was pointing at (0 = A, 1 = B) */
+  libspectrum_snap_set_out_ay2_active_chip( snap, **buffer & 1 ); (*buffer)++;
 
   libspectrum_snap_set_out_ay2_registerport( snap, **buffer ); (*buffer)++;
 
@@ -3520,6 +3523,10 @@ write_ay2_chunk( libspectrum_buffer *buffer, libspectrum_buffer *data,
                  libspectrum_snap *snap )
 {
   size_t i;
+
+  /* Which chip the NedoPC select latch was pointing at (0 = A, 1 = B) */
+  libspectrum_buffer_write_byte( data,
+                                 libspectrum_snap_out_ay2_active_chip( snap ) );
 
   libspectrum_buffer_write_byte( data,
                                  libspectrum_snap_out_ay2_registerport( snap ) );

--- a/libspectrum/szx.c
+++ b/libspectrum/szx.c
@@ -2829,13 +2829,20 @@ libspectrum_szx_write( libspectrum_buffer *buffer, int *out_flags,
       libspectrum_snap_melodik_active( snap ) ||
       capabilities & LIBSPECTRUM_MACHINE_CAPABILITY_AY ) {
     write_ay_chunk( buffer, block_data, snap );
-  }
 
 #ifdef __LIBRETRO__
-  if( libspectrum_snap_turbosound_active( snap ) ) {
+    /* Written under the same condition as the primary AY chip above (not
+       ay_turbosound_enabled, which can change mid-session via the
+       fuse_turbosound core option without a content reload): frontends
+       size their rewind ring buffer once from the first
+       retro_serialize_size() call and never resize it, so a snapshot
+       whose size depends on a live-toggleable option can grow after that
+       point and silently break the rewind buffer. Tying this chunk to the
+       same, session-constant condition as chip A keeps the size stable
+       regardless of whether TurboSound is actually turned on. */
     write_ay2_chunk( buffer, block_data, snap );
-  }
 #endif
+  }
 
   if( capabilities & ( LIBSPECTRUM_MACHINE_CAPABILITY_TIMEX_MEMORY |
                        LIBSPECTRUM_MACHINE_CAPABILITY_SE_MEMORY ) ) {

--- a/libspectrum/szx.c
+++ b/libspectrum/szx.c
@@ -87,6 +87,13 @@ static const libspectrum_word ZXSTRF_COMPRESSED = 1;
 static const libspectrum_byte ZXSTAYF_FULLERBOX = 1;
 static const libspectrum_byte ZXSTAYF_128AY = 2;
 
+#ifdef __LIBRETRO__
+/* Non-standard chunk: second AY-3-8912 chip (TurboSound). Not part of the
+   real SZX spec - only ever written/read by this core, for round-tripping
+   save states/rewind. Standard SZX readers safely skip unknown chunks. */
+#define ZXSTBID_AY2 "AY2\0"
+#endif
+
 #define ZXSTBID_MULTIFACE "MFCE"
 static const libspectrum_byte ZXSTMF_PAGEDIN = 1;
 static const libspectrum_byte ZXSTMF_COMPRESSED = 2;
@@ -287,6 +294,11 @@ write_rom_chunk( libspectrum_buffer *buffer, libspectrum_buffer *block_data,
 static void
 write_ay_chunk( libspectrum_buffer *buffer, libspectrum_buffer *data,
                 libspectrum_snap *snap );
+#ifdef __LIBRETRO__
+static void
+write_ay2_chunk( libspectrum_buffer *buffer, libspectrum_buffer *data,
+                 libspectrum_snap *snap );
+#endif
 static void
 write_scld_chunk( libspectrum_buffer *buffer, libspectrum_buffer *data,
                   libspectrum_snap *snap );
@@ -495,6 +507,34 @@ read_ay_chunk( libspectrum_snap *snap, libspectrum_word version GCC_UNUSED,
 
   return LIBSPECTRUM_ERROR_NONE;
 }
+
+#ifdef __LIBRETRO__
+static libspectrum_error
+read_ay2_chunk( libspectrum_snap *snap, libspectrum_word version GCC_UNUSED,
+	        const libspectrum_byte **buffer,
+	        const libspectrum_byte *end GCC_UNUSED, size_t data_length,
+                szx_context *ctx GCC_UNUSED )
+{
+  size_t i;
+
+  if( data_length != 17 ) {
+    libspectrum_print_error( LIBSPECTRUM_ERROR_UNKNOWN,
+			     "szx_read_ay2_chunk: unknown length %lu",
+			     (unsigned long)data_length );
+    return LIBSPECTRUM_ERROR_UNKNOWN;
+  }
+
+  libspectrum_snap_set_turbosound_active( snap, 1 );
+
+  libspectrum_snap_set_out_ay2_registerport( snap, **buffer ); (*buffer)++;
+
+  for( i = 0; i < 16; i++ ) {
+    libspectrum_snap_set_ay2_registers( snap, i, **buffer ); (*buffer)++;
+  }
+
+  return LIBSPECTRUM_ERROR_NONE;
+}
+#endif /* #ifdef __LIBRETRO__ */
 
 static libspectrum_error
 read_b128_chunk( libspectrum_snap *snap, libspectrum_word version GCC_UNUSED,
@@ -2465,6 +2505,9 @@ struct read_chunk_t {
 static struct read_chunk_t read_chunks[] = {
 
   { ZXSTBID_AY,		         read_ay_chunk   },
+#ifdef __LIBRETRO__
+  { ZXSTBID_AY2,	         read_ay2_chunk  },
+#endif
   { ZXSTBID_BETA128,	         read_b128_chunk },
   { ZXSTBID_BETADISK,	         skip_chunk      },
   { ZXSTBID_COVOX,	         read_covx_chunk },
@@ -2787,6 +2830,12 @@ libspectrum_szx_write( libspectrum_buffer *buffer, int *out_flags,
       capabilities & LIBSPECTRUM_MACHINE_CAPABILITY_AY ) {
     write_ay_chunk( buffer, block_data, snap );
   }
+
+#ifdef __LIBRETRO__
+  if( libspectrum_snap_turbosound_active( snap ) ) {
+    write_ay2_chunk( buffer, block_data, snap );
+  }
+#endif
 
   if( capabilities & ( LIBSPECTRUM_MACHINE_CAPABILITY_TIMEX_MEMORY |
                        LIBSPECTRUM_MACHINE_CAPABILITY_SE_MEMORY ) ) {
@@ -3430,6 +3479,24 @@ write_ay_chunk( libspectrum_buffer *buffer, libspectrum_buffer *data,
 
   write_chunk( buffer, ZXSTBID_AY, data );
 }
+
+#ifdef __LIBRETRO__
+static void
+write_ay2_chunk( libspectrum_buffer *buffer, libspectrum_buffer *data,
+                 libspectrum_snap *snap )
+{
+  size_t i;
+
+  libspectrum_buffer_write_byte( data,
+                                 libspectrum_snap_out_ay2_registerport( snap ) );
+
+  for( i = 0; i < 16; i++ )
+    libspectrum_buffer_write_byte( data,
+                                   libspectrum_snap_ay2_registers( snap, i ) );
+
+  write_chunk( buffer, ZXSTBID_AY2, data );
+}
+#endif /* #ifdef __LIBRETRO__ */
 
 static void
 write_scld_chunk( libspectrum_buffer *buffer, libspectrum_buffer *data,

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -618,6 +618,16 @@ static struct retro_core_option_v2_definition core_option_definitions[] = {
       "none"
    },
    {
+      "fuse_turbosound",
+      "TurboSound (2x AY-8910)",
+      NULL,
+      NULL,
+      NULL,
+      "audio",
+      { CORE_OPTION_VALUE_LIST_ENABLED_DISABLED },
+      "disabled"
+   },
+   {
       "fuse_key_ovrlay_transp",
       "Transparent Keyboard Overlay",
       NULL,
@@ -1114,6 +1124,7 @@ int update_variables(int force)
       auto_size_savestate = FALSE;
 
    ay_turbosound_enabled = coreopt(env_cb, core_vars, "fuse_turbosound", NULL) == 1;
+
    settings_current.mouse_swap_buttons = coreopt(env_cb, core_vars, "fuse_mouse_swap_buttons", NULL) == 1;
 
    const char* value;

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -14,6 +14,7 @@
 #include <spectrum.h>
 #include <keyboard.h>
 #include <machines/specplus3.h>
+#include <peripherals/ay.h>
 #include <peripherals/disk/beta.h>
 #include <peripherals/disk/plusd.h>
 #include <peripherals/if1.h>
@@ -414,6 +415,7 @@ static const struct retro_variable core_vars[] =
    { "fuse_load_sound", "Tape Load Sound; enabled|disabled" },
    { "fuse_speaker_type", "Speaker Type; tv speaker|beeper|unfiltered" },
    { "fuse_ay_stereo_separation", "AY Stereo Separation; none|acb|abc" },
+   { "fuse_turbosound", "TurboSound (2x AY-8910); disabled|enabled" },
    { "fuse_key_ovrlay_transp", "Transparent Keyboard Overlay; enabled|disabled" },
    { "fuse_key_hold_time", "Time to Release Key in ms; 500|1000|100|300" },
    { "fuse_display_joystick_type", "Display joystick type and emulation speed at startup; enabled|disabled" },
@@ -660,6 +662,8 @@ int update_variables(int force)
       auto_size_savestate = TRUE;
    else
       auto_size_savestate = FALSE;
+
+   ay_turbosound_enabled = coreopt(env_cb, core_vars, "fuse_turbosound", NULL) == 1;
 
    const char* value;
    int option = coreopt(env_cb, core_vars, "fuse_joypad_up", &value );

--- a/src/libspectrum.h
+++ b/src/libspectrum.h
@@ -869,6 +869,15 @@ LIBSPECTRUM_API libspectrum_byte libspectrum_snap_out_ay_registerport( libspectr
 LIBSPECTRUM_API void libspectrum_snap_set_out_ay_registerport( libspectrum_snap *snap, libspectrum_byte out_ay_registerport );
 LIBSPECTRUM_API libspectrum_byte libspectrum_snap_ay_registers( libspectrum_snap *snap, int idx );
 LIBSPECTRUM_API void libspectrum_snap_set_ay_registers( libspectrum_snap *snap, int idx, libspectrum_byte ay_registers );
+/* TurboSound: second AY-3-8912 chip (fuse-libretro only) */
+LIBSPECTRUM_API int libspectrum_snap_turbosound_active( libspectrum_snap *snap );
+LIBSPECTRUM_API void libspectrum_snap_set_turbosound_active( libspectrum_snap *snap, int turbosound_active );
+LIBSPECTRUM_API libspectrum_byte libspectrum_snap_out_ay2_registerport( libspectrum_snap *snap );
+LIBSPECTRUM_API void libspectrum_snap_set_out_ay2_registerport( libspectrum_snap *snap, libspectrum_byte out_ay2_registerport );
+LIBSPECTRUM_API libspectrum_byte libspectrum_snap_ay2_registers( libspectrum_snap *snap, int idx );
+LIBSPECTRUM_API void libspectrum_snap_set_ay2_registers( libspectrum_snap *snap, int idx, libspectrum_byte ay2_registers );
+LIBSPECTRUM_API libspectrum_byte libspectrum_snap_out_ay2_active_chip( libspectrum_snap *snap );
+LIBSPECTRUM_API void libspectrum_snap_set_out_ay2_active_chip( libspectrum_snap *snap, libspectrum_byte out_ay2_active_chip );
 LIBSPECTRUM_API libspectrum_byte libspectrum_snap_out_scld_hsr( libspectrum_snap *snap );
 LIBSPECTRUM_API void libspectrum_snap_set_out_scld_hsr( libspectrum_snap *snap, libspectrum_byte out_scld_hsr );
 LIBSPECTRUM_API libspectrum_byte libspectrum_snap_out_scld_dec( libspectrum_snap *snap );


### PR DESCRIPTION
Emulates a second AY-3-8910/YM2149 chip using the classic **NedoPC protocol**, the convention used by real Pentagon/Scorpion TurboSound boards: writing a value with its top 5 bits all set (`0xF8`-`0xFF`, never a valid register index since a single AY only has registers 0-15) to the register-select port (`#FFFD`) selects the active chip instead of a register, via bit 0 of that value. No new ports are needed - `#FFFD`/`#BFFD` keep addressing whichever chip is currently selected, and chip A is the reset default, so content that never performs a chip-select keeps working exactly as before.

**Verified this is the correct protocol against two independent open-source implementations** before writing any code: zesarux's `out_port_ay()` turned out to implement the newer, different TurboSound Next (4-chip) scheme; xpeccy's `tsOut()` has a dedicated `TS_NEDOPC` case matching the description above byte-for-byte, confirmed by reading its actual source rather than relying on a web summary (which had the chip A/B byte values backwards).

**Changes:**
- `fuse/peripherals/ay.c`/`.h`: a second `ayinfo` chip and the chip-select dispatch, gated behind `ay_turbosound_enabled`.
- `fuse/sound.c`/`.h`: the tone/noise/envelope generators and `Blip_Synth` mixing, previously hardcoded to one chip, are now parametrized by chip index and driven twice per frame when enabled.
- `src/libretro.c`: `fuse_turbosound` core option (disabled|enabled, default disabled).
- `libspectrum/szx.c` + `snap_accessors.c`/`.txt`: a new `"AY2\0"` SZX chunk so `retro_serialize`/`retro_unserialize` (save states, rewind) round-trip the second chip's registers. This isn't part of the real zx-state spec - there's no standard second-AY chunk to converge on - but that's safe: SZX is length-prefixed and forward-extensible, so any conformant reader (real Fuse, Spectaculator, ZEsarUX) silently skips this chunk and degrades to single-chip audio instead of failing to load.

**Testing**

Verified with a standalone libretro test harness and real RetroArch: default (disabled) behavior is unchanged, `fuse_turbosound=enabled` runs without hangs or crashes, and a save-state round-trip on a 128K machine preserves both chips' register state. Directly proved the chip-select dispatch logic (not just "doesn't crash") with a temporary self-test driving the exact NedoPC byte sequence through `ay_registerport_write`/`ay_dataport_write` and confirming chip A and chip B end up with independent register state.