### PR TITLE
Fix initial video geometry for non-full border modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ fuse/roms/*.h
 fuse/lib/compressed/*.h
 libspectrum/*.h
 version.c
+.vscode/pro-deployer.json

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -1953,10 +1953,9 @@ void retro_set_input_poll(retro_input_poll_t cb)
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
-   // Here we always use the "hard" resolution to accomodate output with *and*
-   // without the video border
-   info->geometry.base_width = hard_width;
-   info->geometry.base_height = hard_height;
+   // Report the currently visible output geometry.
+   info->geometry.base_width = soft_width;
+   info->geometry.base_height = soft_height;
 
    info->geometry.max_width = MAX_WIDTH;
    info->geometry.max_height = MAX_HEIGHT;


### PR DESCRIPTION
This should fix this report: https://github.com/libretro/fuse-libretro/commit/0a5a58e77ffd8c7a25ce3ce4734a54716f13bfdc