### PR TITLE
Revert "Fix initial video geometry for non-full border modes"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ fuse/roms/*.h
 fuse/lib/compressed/*.h
 libspectrum/*.h
 version.c
-.vscode/pro-deployer.json

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -1953,9 +1953,10 @@ void retro_set_input_poll(retro_input_poll_t cb)
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
-   // Report the currently visible output geometry.
-   info->geometry.base_width = soft_width;
-   info->geometry.base_height = soft_height;
+   // Here we always use the "hard" resolution to accomodate output with *and*
+   // without the video border
+   info->geometry.base_width = hard_width;
+   info->geometry.base_height = hard_height;
 
    info->geometry.max_width = MAX_WIDTH;
    info->geometry.max_height = MAX_HEIGHT;


### PR DESCRIPTION
Reverts libretro/fuse-libretro#170

It seems that this change doe not work in Retroarch, so revert it back until getting a better fix for the borders issue.
I won't PR anymore until getting confirmation on the code changes anymore.