### PR TITLE
use the frontend keyboard callback, with port polling as a fallback

### DIFF
--- a/src/compat/ui.c
+++ b/src/compat/ui.c
@@ -241,43 +241,49 @@ int ui_event(void)
          }
       }
       
+      // The keyboard belongs to the machine, not to a controller port, so
+      // read it one time per frame from a single source.
+      unsigned kb_port = 0;
+
       for (port = 0; port < MAX_PADS; port++)
       {
-         unsigned device = input_devices[port];
-         
-         if (device == RETRO_DEVICE_SPECTRUM_KEYBOARD)
+         if (input_devices[port] == RETRO_DEVICE_SPECTRUM_KEYBOARD)
          {
-            for (id = 0; keysyms_map[id].ui; id++)
+            kb_port = port;
+            break;
+         }
+      }
+
+      for (id = 0; keysyms_map[id].ui; id++)
+      {
+         unsigned ui = keysyms_map[id].ui;
+         is_down = kb_cb_active ? kb_cb_state[ui]
+                                : input_state_cb(kb_port, RETRO_DEVICE_KEYBOARD, 0, ui);
+
+         if (is_down)
+         {
+            if (!keyb_state[ui])
             {
-               unsigned ui = keysyms_map[id].ui;
-               is_down = input_state_cb(port, RETRO_DEVICE_KEYBOARD, 0, ui);
-               
-               if (is_down)
-               {
-                  if (!keyb_state[ui])
-                  {
-                     keyb_state[ui] = true;
-                 
-                     fuse_event.type = INPUT_EVENT_KEYPRESS;
-                     fuse_event.types.key.native_key = keysyms_map[id].fuse;
-                     fuse_event.types.key.spectrum_key = keysyms_map[id].fuse;
-              
-                     input_event(&fuse_event);
-                  }
-               }
-               else
-               {
-                  if (keyb_state[ui])
-                  {
-                     keyb_state[ui] = false;
-                 
-                     fuse_event.type = INPUT_EVENT_KEYRELEASE;
-                     fuse_event.types.key.native_key = keysyms_map[id].fuse;
-                     fuse_event.types.key.spectrum_key = keysyms_map[id].fuse;
-              
-                     input_event(&fuse_event);
-                  }
-               }
+               keyb_state[ui] = true;
+
+               fuse_event.type = INPUT_EVENT_KEYPRESS;
+               fuse_event.types.key.native_key = keysyms_map[id].fuse;
+               fuse_event.types.key.spectrum_key = keysyms_map[id].fuse;
+
+               input_event(&fuse_event);
+            }
+         }
+         else
+         {
+            if (keyb_state[ui])
+            {
+               keyb_state[ui] = false;
+
+               fuse_event.type = INPUT_EVENT_KEYRELEASE;
+               fuse_event.types.key.native_key = keysyms_map[id].fuse;
+               fuse_event.types.key.spectrum_key = keysyms_map[id].fuse;
+
+               input_event(&fuse_event);
             }
          }
       }

--- a/src/externs.h
+++ b/src/externs.h
@@ -54,6 +54,8 @@ extern unsigned keyb_x;
 extern unsigned keyb_y;
 extern bool joyp_state[MAX_PADS][16];
 extern bool keyb_state[RETROK_LAST];
+extern bool kb_cb_state[RETROK_LAST];
+extern bool kb_cb_active;
 extern void* snapshot_buffer;
 extern size_t snapshot_size;
 extern void* tape_data;

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -332,6 +332,19 @@ unsigned keyb_x;
 unsigned keyb_y;
 bool joyp_state[MAX_PADS][16];
 bool keyb_state[RETROK_LAST];
+
+bool kb_cb_state[RETROK_LAST];
+bool kb_cb_active = false;
+
+static void RETRO_CALLCONV keyboard_event_cb(bool down, unsigned keycode, uint32_t character, uint16_t mod)
+{
+   (void)character;
+   (void)mod;
+
+   if (keycode < RETROK_LAST)
+      kb_cb_state[keycode] = down;
+}
+
 void*  snapshot_buffer;
 size_t snapshot_size;
 void* tape_data;
@@ -1497,9 +1510,12 @@ void retro_set_environment(retro_environment_t cb)
       { NULL, 0 }
    };
 
+   static const struct retro_keyboard_callback kb_callback = { keyboard_event_cb };
+
    bool yes = true;
    unsigned core_options_version = 0;
    cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &yes);
+   kb_cb_active = cb(RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK, (void*)&kb_callback);
 
    if (cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &core_options_version) &&
        core_options_version >= 2)
@@ -1887,6 +1903,7 @@ bool retro_load_game(const struct retro_game_info *info)
    env_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, input_descriptors);
    memset(joyp_state, 0, sizeof(joyp_state));
    memset(keyb_state, 0, sizeof(keyb_state));
+   memset(kb_cb_state, 0, sizeof(kb_cb_state));
    hard_width = hard_height = soft_width = soft_height = 0;
    select_pressed = keyb_overlay = 0;
    keyb_x = keyb_y = 0;


### PR DESCRIPTION
At the moment, the core only polls the keyboard on ports configured as `RETRO_DEVICE_SPECTRUM_KEYBOARD`. Frontends without a controller-type selection UI can remove that assignment.

RALibretro [sets](https://github.com/RetroAchievements/RALibretro/blob/8ab61f745ab753a70b5482f2a0ccb6a4ced5193f/src/libretro/Core.cpp#L515-L519) every declared port to `RETRO_DEVICE_NONE` right after `retro_load_game()`. After that, the core polls no input device. Spectrum games load and then the player is effectively stuck in the game's menu. Keys pressed by the player never reach the game. This issue is [documented](https://docs.retroachievements.org/developer-docs/unsupported-emulators-and-cores.html#zx-spectrum) as "requires ability to map keyboard to port 3" in RetroAchievements' unsupported cores page for fuse-libretro.

The Spectrum's keyboard is not an optional peripheral. This PR registers the frontend keyboard callback (`RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK`) and uses it as the keyboard source. Frontends deliver the callback regardless of their controller port configuration. Given all ports are set to joysticks, the keyboard will no longer be silenced or configured away. This is consistent with what other computer cores ([C64](https://github.com/libretro/vice-libretro/blob/c8c242db75a559246d6d51017e6dd4ecd75d6a9f/libretro/libretro-core.c#L7758), [CPC](https://github.com/libretro/libretro-cap32/blob/4abfb8be233bec630f369379fb6c1d92d31f1c7d/libretro/retro_events.c#L735), [DOS](https://github.com/schellingb/dosbox-pure/blob/7f6e8fb7385fa446d1444d671063268520bf9b54/dosbox_pure_libretro.cpp#L3039)) already do.

When a frontend does not support the callback, the core falls back to polling `RETRO_DEVICE_KEYBOARD` on the first port set to Sinclair Keyboard, or on port 0 when there is none.

RetroArch behavior is unchanged by this PR in practice. It already supports the callback, so the keyboard source moves from port 3 polling to the callback and defaults keep working. RALibretro [also](https://github.com/RetroAchievements/RALibretro/blob/8ab61f745ab753a70b5482f2a0ccb6a4ced5193f/src/libretro/Core.cpp#L1950) supports the callback, so keyboard input now works there even with every port set to `RETRO_DEVICE_NONE`. The polling fallback only matters for frontends that do not implement the callback.